### PR TITLE
fix an issue with compiling for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,10 @@ let package = Package(
       .target(
           name: "NumSwiftC",
           dependencies: [],
-          resources: []),
+          cSettings: [
+            .define("__ARM_FEATURE_FP16_VECTOR_ARITHMETIC", .when(platforms: [.iOS, .tvOS, .watchOS])),
+            .unsafeFlags(["-march=armv8.2-a+fp16"], .when(platforms: [.iOS, .tvOS, .watchOS]))
+          ]),
       .target(
             name: "NumSwift",
             dependencies: ["NumSwiftC"],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configure `NumSwiftC` C build settings to enable ARMv8.2 FP16 on iOS/tvOS/watchOS, addressing iOS compilation issues.
> 
> - **Build configuration**:
>   - Update `Package.swift` to set `NumSwiftC` `cSettings` for Apple mobile platforms:
>     - Define `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC`.
>     - Add `-march=armv8.2-a+fp16` unsafe flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffeae323bc2811e8a0f283dd789f780b31d0761e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->