### PR TITLE
Develop

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,10 @@ let package = Package(
       .target(
           name: "NumSwiftC",
           dependencies: [],
-          resources: []),
+          cSettings: [
+            .define("__ARM_FEATURE_FP16_VECTOR_ARITHMETIC", .when(platforms: [.iOS, .tvOS, .watchOS])),
+            .unsafeFlags(["-march=armv8.2-a+fp16"], .when(platforms: [.iOS, .tvOS, .watchOS]))
+          ]),
       .target(
             name: "NumSwift",
             dependencies: ["NumSwiftC"],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configures `NumSwiftC` target with ARMv8.2 FP16 C settings for Apple platforms and removes unused resources entry.
> 
> - **Build/Package (`Package.swift`)**:
>   - Configure `NumSwiftC` target `cSettings`:
>     - Define `__ARM_FEATURE_FP16_VECTOR_ARITHMETIC` for `.iOS`, `.tvOS`, `.watchOS`.
>     - Add `-march=armv8.2-a+fp16` via `unsafeFlags` for the same platforms.
>   - Remove empty `resources: []` from `NumSwiftC` target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0848a8f5cf2509801df0c62fbf57e706143d4da0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->