### PR TITLE
added new 3d flatten functions

### DIFF
--- a/Sources/NumSwift/Float16.swift
+++ b/Sources/NumSwift/Float16.swift
@@ -17,7 +17,7 @@ public extension Array where Element == [Float16] {
   }
   
   func flatten(inputSize: (rows: Int, columns: Int)? = nil) -> [Self.Element.Element] {
-    NumSwiftC.flatten(self, inputSize: inputSize)
+    return self.flatMap { $0 }
   }
   
   func transpose2d() -> Self {
@@ -336,7 +336,7 @@ public extension Array where Element == [[Float16]] {
   }
   
   func flatten(inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float16] {
-    NumSwiftC.flatten(self, inputSize: inputSize)
+    flatMap { $0.flatMap { $0 } }
   }
   
   /// Uses `vDSP_mtrans` to transpose each 2D array throughout the depth of the array

--- a/Sources/NumSwift/Float16.swift
+++ b/Sources/NumSwift/Float16.swift
@@ -16,8 +16,8 @@ public extension Array where Element == [Float16] {
     return [cols, rows]
   }
   
-  func flatten(inputSize: (rows: Int, columns: Int)? = nil) -> [Self.Element.Element] {
-    return self.flatMap { $0 }
+  func flatten() -> [Self.Element.Element] {
+     flatMap { $0 }
   }
   
   func transpose2d() -> Self {
@@ -335,7 +335,7 @@ public extension Array where Element == [[Float16]] {
     return r
   }
   
-  func flatten(inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float16] {
+  func flatten() -> [Float16] {
     flatMap { $0.flatMap { $0 } }
   }
   

--- a/Sources/NumSwift/Float16.swift
+++ b/Sources/NumSwift/Float16.swift
@@ -335,6 +335,10 @@ public extension Array where Element == [[Float16]] {
     return r
   }
   
+  func flatten(inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float16] {
+    NumSwiftC.flatten(self, inputSize: inputSize)
+  }
+  
   /// Uses `vDSP_mtrans` to transpose each 2D array throughout the depth of the array
   /// - Returns: The transposed array
   func transpose2d() -> Self {

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -414,6 +414,10 @@ public extension Array where Element == [[Float]] {
     return r
   }
   
+  func flatten(inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float] {
+    NumSwiftC.flatten(self, inputSize: inputSize)
+  }
+  
   /// Uses `vDSP_mtrans` to transpose each 2D array throughout the depth of the array
   /// - Returns: The transposed array
   func transpose2d() -> Self {

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -491,102 +491,83 @@ public extension Array where Element == [[Float]] {
   
   static func /(lhs: Float, rhs: Self) -> Self {
     var result: Self = []
+    result.reserveCapacity(rhs.count)
     for d in 0..<rhs.count {
       let new2d: Element = rhs[d].map { lhs / $0 }
       result.append(new2d)
     }
-    
     return result
   }
-  
+
   static func +(lhs: Self, rhs: Float) -> Self {
     var result: Self = []
+    result.reserveCapacity(lhs.count)
     for d in 0..<lhs.count {
-      let new2d = NumSwiftC.add(lhs[d], scalar: rhs)
-      result.append(new2d)
+      result.append(NumSwiftC.add(lhs[d], scalar: rhs))
     }
-    
     return result
   }
-  
+
   static func +(lhs: Float, rhs: Self) -> Self {
     var result: Self = []
+    result.reserveCapacity(rhs.count)
     for d in 0..<rhs.count {
-      let new2d = NumSwiftC.add(rhs[d], scalar: lhs)
-      result.append(new2d)
+      result.append(NumSwiftC.add(rhs[d], scalar: lhs))
     }
-    
     return result
   }
-  
+
   static func -(lhs: Float, rhs: Self) -> Self {
     var result: Self = []
+    result.reserveCapacity(rhs.count)
     for d in 0..<rhs.count {
       let new2d: Element = rhs[d].map { lhs - $0 }
       result.append(new2d)
     }
-    
     return result
   }
-  
+
   static func -(lhs: Self, rhs: Float) -> Self {
     var result: Self = []
+    result.reserveCapacity(lhs.count)
     for d in 0..<lhs.count {
-      let new2d = NumSwiftC.sub(lhs[d], scalar: rhs)
-      result.append(new2d)
+      result.append(NumSwiftC.sub(lhs[d], scalar: rhs))
     }
-    
     return result
   }
   
   static func *(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
     var result: Self = []
+    result.reserveCapacity(lhs.count)
     for i in 0..<lhs.count {
-      let a = lhs[i]
-      let b = rhs[i]
-      result.append(NumSwiftC.mult(a, b))
+      result.append(NumSwiftC.mult(lhs[i], rhs[i]))
     }
     return result
   }
-  
+
   static func /(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
     var result: Self = []
+    result.reserveCapacity(lhs.count)
     for i in 0..<lhs.count {
-      let a = lhs[i]
-      let b = rhs[i]
-      result.append(NumSwiftC.divide(a, b))
+      result.append(NumSwiftC.divide(lhs[i], rhs[i]))
     }
     return result
   }
-  
+
   static func -(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
     var result: Self = []
+    result.reserveCapacity(lhs.count)
     for i in 0..<lhs.count {
-      let a = lhs[i]
-      let b = rhs[i]
-      result.append(NumSwiftC.sub(a, b))
+      result.append(NumSwiftC.sub(lhs[i], rhs[i]))
     }
     return result
   }
-  
+
   static func +(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
     var result: Self = []
+    result.reserveCapacity(lhs.count)
     for i in 0..<lhs.count {
-      let a = lhs[i]
-      let b = rhs[i]
-      result.append(NumSwiftC.add(a, b))
+      result.append(NumSwiftC.add(lhs[i], rhs[i]))
     }
     return result
   }
@@ -1003,78 +984,42 @@ public extension Array where Element == [Float] {
   }
   
   static func *(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
-    let leftShape = left.shape
-    let rightShape = right.shape
-    
-    precondition(leftShape == rightShape)
-    
-    let depth = left.count
-    
+    assert(lhs.shape == rhs.shape)
     var result: Self = []
-    for d in 0..<depth {
-      result.append(left[d] * right[d])
+    result.reserveCapacity(lhs.count)
+    for d in 0..<lhs.count {
+      result.append(lhs[d] * rhs[d])
     }
-    
     return result
   }
-  
+
   static func /(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
-    let leftShape = left.shape
-    let rightShape = right.shape
-    
-    precondition(leftShape == rightShape)
-    
-    let depth = left.count
-    
+    assert(lhs.shape == rhs.shape)
     var result: Self = []
-    for d in 0..<depth {
-      result.append(left[d] / right[d])
+    result.reserveCapacity(lhs.count)
+    for d in 0..<lhs.count {
+      result.append(lhs[d] / rhs[d])
     }
-    
     return result
   }
-  
+
   static func -(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
-    let leftShape = left.shape
-    let rightShape = right.shape
-    
-    precondition(leftShape == rightShape)
-    
-    let depth = left.count
-    
+    assert(lhs.shape == rhs.shape)
     var result: Self = []
-    for d in 0..<depth {
-      result.append(left[d] - right[d])
+    result.reserveCapacity(lhs.count)
+    for d in 0..<lhs.count {
+      result.append(lhs[d] - rhs[d])
     }
-    
     return result
   }
-  
+
   static func +(lhs: Self, rhs: Self) -> Self {
-    let left = lhs
-    let right = rhs
-    
-    let leftShape = left.shape
-    let rightShape = right.shape
-    
-    precondition(leftShape == rightShape)
-    
-    let depth = left.count
-    
+    assert(lhs.shape == rhs.shape)
     var result: Self = []
-    for d in 0..<depth {
-      result.append(left[d] + right[d])
+    result.reserveCapacity(lhs.count)
+    for d in 0..<lhs.count {
+      result.append(lhs[d] + rhs[d])
     }
-    
     return result
   }
 }

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -16,7 +16,7 @@ public extension Array where Element == [Float] {
   }
   
   func flatten(inputSize: (rows: Int, columns: Int)? = nil) -> [Self.Element.Element] {
-    NumSwiftC.flatten(self, inputSize: inputSize)
+    flatMap { $0 }
   }
   
   func transpose2d() -> Self {
@@ -415,7 +415,7 @@ public extension Array where Element == [[Float]] {
   }
   
   func flatten(inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float] {
-    NumSwiftC.flatten(self, inputSize: inputSize)
+    flatMap { $0.flatMap { $0 } }
   }
   
   /// Uses `vDSP_mtrans` to transpose each 2D array throughout the depth of the array

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -984,7 +984,7 @@ public extension Array where Element == [Float] {
   }
   
   static func *(lhs: Self, rhs: Self) -> Self {
-    assert(lhs.shape == rhs.shape)
+    precondition(lhs.shape == rhs.shape)
     var result: Self = []
     result.reserveCapacity(lhs.count)
     for d in 0..<lhs.count {
@@ -994,7 +994,7 @@ public extension Array where Element == [Float] {
   }
 
   static func /(lhs: Self, rhs: Self) -> Self {
-    assert(lhs.shape == rhs.shape)
+    precondition(lhs.shape == rhs.shape)
     var result: Self = []
     result.reserveCapacity(lhs.count)
     for d in 0..<lhs.count {
@@ -1004,7 +1004,7 @@ public extension Array where Element == [Float] {
   }
 
   static func -(lhs: Self, rhs: Self) -> Self {
-    assert(lhs.shape == rhs.shape)
+    precondition(lhs.shape == rhs.shape)
     var result: Self = []
     result.reserveCapacity(lhs.count)
     for d in 0..<lhs.count {
@@ -1014,7 +1014,7 @@ public extension Array where Element == [Float] {
   }
 
   static func +(lhs: Self, rhs: Self) -> Self {
-    assert(lhs.shape == rhs.shape)
+    precondition(lhs.shape == rhs.shape)
     var result: Self = []
     result.reserveCapacity(lhs.count)
     for d in 0..<lhs.count {

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -15,7 +15,7 @@ public extension Array where Element == [Float] {
     return [cols, rows]
   }
   
-  func flatten(inputSize: (rows: Int, columns: Int)? = nil) -> [Self.Element.Element] {
+  func flatten() -> [Self.Element.Element] {
     flatMap { $0 }
   }
   
@@ -414,7 +414,7 @@ public extension Array where Element == [[Float]] {
     return r
   }
   
-  func flatten(inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float] {
+  func flatten() -> [Float] {
     flatMap { $0.flatMap { $0 } }
   }
   

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
@@ -392,6 +392,7 @@ public struct NumSwiftC {
     return results
   }
   
+  // expects the array to be fully symetrical with each dimension containing the smae number of elements
   public static func flatten(_ input: [[[Float]]], inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float] {
     
     let shape = input.shape
@@ -423,6 +424,7 @@ public struct NumSwiftC {
     return results
   }
   
+  // expects the array to be fully symetrical with each dimension containing the smae number of elements
   public static func flatten(_ input: [[Float]], inputSize: (rows: Int, columns: Int)? = nil) -> [Float] {
     
     let shape = input.shape

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
@@ -8,6 +8,12 @@
 import Foundation
 import NumSwiftC
 
+public extension NSC_Size {
+  init(rows: Int32, columns: Int32) {
+    self.init(rows: rows, columns: columns, depth: 1)
+  }
+}
+
 public struct NoiseC {
   public var octaves = 4
   public var amplitude = 0.5
@@ -381,6 +387,37 @@ public struct NumSwiftC {
                      &rPoint)
         }
       }
+    }
+    
+    return results
+  }
+  
+  public static func flatten(_ input: [[[Float]]], inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float] {
+    
+    let shape = input.shape
+    var rows = shape[safe: 1, 0]
+    var columns = shape[safe: 0, 0]
+    var depth = shape[safe: 2, 0]
+
+    
+    if let inputSize = inputSize {
+      rows = inputSize.rows
+      columns = inputSize.columns
+      depth = inputSize.depth
+    }
+    
+    var results: [Float] = [Float](repeating: 0, count: rows * columns * depth)
+
+    // Convert each 2D slice to a flat array of row pointers
+    var slicePointers: [[UnsafeMutablePointer<Float>?]] = input.map { slice in
+      slice.map { UnsafeMutablePointer(mutating: $0) }
+    }
+    
+    // Create an array of pointers to each slice's pointer array
+    slicePointers.withUnsafeBufferPointer { sliceBuffer in
+      let inPuts: [UnsafePointer<UnsafeMutablePointer<Float>?>?] = sliceBuffer.map { UnsafePointer($0) }
+      
+      nsc_flatten3d(NSC_Size(rows: Int32(rows), columns: Int32(columns), depth: Int32(depth)), inPuts, &results)
     }
     
     return results

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
@@ -11,7 +11,7 @@ import NumSwiftC
 #if arch(arm64)
 public extension NumSwiftC {
   
-  public static func add(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
+  static func add(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -38,7 +38,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func sub(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
+  static func sub(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -65,7 +65,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func divide(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
+  static func divide(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -92,7 +92,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func mult(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
+  static func mult(_ a: [[Float16]], _ b: [[Float16]]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -121,7 +121,7 @@ public extension NumSwiftC {
   
   // MARK: - 2D Arithmetic with Scalar Operations
   
-  public static func add(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
+  static func add(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -145,7 +145,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func add(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
+  static func add(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -169,7 +169,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func sub(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
+  static func sub(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -193,7 +193,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func sub(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
+  static func sub(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -217,7 +217,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func mult(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
+  static func mult(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -241,7 +241,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func mult(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
+  static func mult(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -265,7 +265,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func divide(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
+  static func divide(_ a: [[Float16]], scalar: Float16) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -289,7 +289,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func divide(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
+  static func divide(_ a: [[Float16]], array: [Float16]) -> [[Float16]] {
     let shape = a.shape
     let rows = shape[safe: 1] ?? 0
     let columns = shape[safe: 0] ?? 0
@@ -313,7 +313,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func tranpose(_ a: [[Float16]], size: (rows: Int, columns: Int)) -> [[Float16]] {
+  static func tranpose(_ a: [[Float16]], size: (rows: Int, columns: Int)) -> [[Float16]] {
     let result: [[Float16]] = NumSwift.zerosLike((rows: size.columns, columns: size.rows))
     
     result.withUnsafeBufferPointer { rBuff in
@@ -332,7 +332,7 @@ public extension NumSwiftC {
     return result
   }
   
-  public static func matmul(_ a: [[Float16]],
+  static func matmul(_ a: [[Float16]],
                             b: [[Float16]],
                             aSize: (rows: Int, columns: Int),
                             bSize: (rows: Int, columns: Int)) -> [[Float16]] {
@@ -359,14 +359,13 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func flatten(_ input: [[[Float16]]], inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float16] {
+  static func flatten(_ input: [[[Float16]]], inputSize: (rows: Int, columns: Int, depth: Int)? = nil) -> [Float16] {
     
     let shape = input.shape
     var rows = shape[safe: 1, 0]
     var columns = shape[safe: 0, 0]
     var depth = shape[safe: 2, 0]
 
-    
     if let inputSize = inputSize {
       rows = inputSize.rows
       columns = inputSize.columns
@@ -390,7 +389,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func flatten(_ input: [[Float16]], inputSize: (rows: Int, columns: Int)? = nil) -> [Float16] {
+  static func flatten(_ input: [[Float16]], inputSize: (rows: Int, columns: Int)? = nil) -> [Float16] {
     
     let shape = input.shape
     var rows = shape[safe: 1, 0]
@@ -412,7 +411,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func stridePad(signal: [[Float16]],
+  static func stridePad(signal: [[Float16]],
                                strides: (rows: Int, columns: Int)) -> [[Float16]] {
     
     guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else {
@@ -445,7 +444,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func stridePad1D(signal: [Float16],
+  static func stridePad1D(signal: [Float16],
                                  strides: (rows: Int, columns: Int)) -> [Float16] {
     
     guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else {
@@ -472,7 +471,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func zeroPad(signal: [[Float16]],
+  static func zeroPad(signal: [[Float16]],
                              padding: NumSwiftPadding) -> [[Float16]] {
     
     guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
@@ -507,7 +506,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func zeroPad(signal: [[Float16]],
+  static func zeroPad(signal: [[Float16]],
                              filterSize: (rows: Int, columns: Int),
                              inputSize: (rows: Int, columns: Int),
                              stride: (Int, Int) = (1,1)) -> [[Float16]] {
@@ -549,7 +548,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func conv2d(signal: [[Float16]],
+  static func conv2d(signal: [[Float16]],
                             filter: [[Float16]],
                             strides: (Int, Int) = (1,1),
                             padding: NumSwift.ConvPadding = .valid,
@@ -583,7 +582,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func conv1d(signal: [Float16],
+  static func conv1d(signal: [Float16],
                             filter: [Float16],
                             strides: (Int, Int) = (1,1),
                             padding: NumSwift.ConvPadding = .valid,
@@ -608,7 +607,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func transConv2d(signal: [[Float16]],
+  static func transConv2d(signal: [[Float16]],
                                  filter: [[Float16]],
                                  strides: (Int, Int) = (1,1),
                                  padding: NumSwift.ConvPadding = .valid,
@@ -660,7 +659,7 @@ public extension NumSwiftC {
   }
   
   
-  public static func transConv1d(signal: [Float16],
+  static func transConv1d(signal: [Float16],
                                  filter: [Float16],
                                  strides: (Int, Int) = (1,1),
                                  padding: NumSwift.ConvPadding = .valid,
@@ -699,7 +698,7 @@ public extension NumSwiftC {
     return results
   }
   
-  public static func zeroPad(signal: [Float16],
+  static func zeroPad(signal: [Float16],
                              filterSize: (rows: Int, columns: Int),
                              inputSize: (rows: Int, columns: Int),
                              stride: (Int, Int) = (1,1)) -> [Float16] {

--- a/Sources/NumSwiftC/include/numswiftc.h
+++ b/Sources/NumSwiftC/include/numswiftc.h
@@ -68,8 +68,16 @@ extern void nsc_flatten2d(NSC_Size input_size,
                           float *const *input,
                           float *result);
 
+extern void nsc_flatten3d(NSC_Size input_size,
+                          float *const *const *input,
+                          float *result);
+
 extern void nsc_flatten2d_16(NSC_Size input_size,
                           __fp16 *const *input,
+                          __fp16 *result);
+
+extern void nsc_flatten3d_16(NSC_Size input_size,
+                          __fp16 *const *const *input,
                           __fp16 *result);
 
 extern void random_array(const int size, double *result);

--- a/Sources/NumSwiftC/include/numswiftc_base.h
+++ b/Sources/NumSwiftC/include/numswiftc_base.h
@@ -34,6 +34,7 @@ typedef struct {
 typedef struct {
   int rows;
   int columns;
+  int depth;
 } NSC_Size;
 
 extern NSC_IndexedValue nsc_index_of_min(const _Float16 array[]);

--- a/Sources/NumSwiftC/numswiftc.c
+++ b/Sources/NumSwiftC/numswiftc.c
@@ -171,6 +171,56 @@ extern void nsc_flatten2d_16(NSC_Size input_size,
   free(padded);
 }
 
+extern void nsc_flatten3d_16(NSC_Size input_size,
+                             __fp16 *const *const *input,
+                             __fp16 *result) {
+  
+  int length = input_size.rows * input_size.columns * input_size.depth;
+  float *padded = malloc(length * sizeof(__fp16));
+  
+  for (int i = 0; i < length; i++) {
+    padded[i] = 0;
+  }
+
+  for (int d = 0; d < input_size.depth; d++) {
+    for (int r = 0; r < input_size.rows; r++) {
+      for (int c = 0; c < input_size.columns; c++) {
+        float value = input[d][r][c];
+        int index = c + r * input_size.columns + d * input_size.columns * input_size.rows;
+        padded[index] = value;
+      }
+    }
+  }
+  
+  memcpy(result, padded, length * sizeof(__fp16));
+  free(padded);
+}
+
+extern void nsc_flatten3d(NSC_Size input_size,
+                          float *const *const *input,
+                          float *result) {
+  
+  int length = input_size.rows * input_size.columns * input_size.depth;
+  float *padded = malloc(length * sizeof(float));
+  
+  for (int i = 0; i < length; i++) {
+    padded[i] = 0;
+  }
+
+  for (int d = 0; d < input_size.depth; d++) {
+    for (int r = 0; r < input_size.rows; r++) {
+      for (int c = 0; c < input_size.columns; c++) {
+        float value = input[d][r][c];
+        int index = c + r * input_size.columns + d * input_size.columns * input_size.rows;
+        padded[index] = value;
+      }
+    }
+  }
+  
+  memcpy(result, padded, length * sizeof(float));
+  free(padded);
+}
+
 extern void nsc_flatten2d(NSC_Size input_size,
                           float *const *input,
                           float *result) {

--- a/Sources/NumSwiftC/numswiftc.c
+++ b/Sources/NumSwiftC/numswiftc.c
@@ -185,7 +185,7 @@ extern void nsc_flatten3d_16(NSC_Size input_size,
   for (int d = 0; d < input_size.depth; d++) {
     for (int r = 0; r < input_size.rows; r++) {
       for (int c = 0; c < input_size.columns; c++) {
-        float value = input[d][r][c];
+        __fp16 value = input[d][r][c];
         int index = c + r * input_size.columns + d * input_size.columns * input_size.rows;
         padded[index] = value;
       }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the C/Swift FFI boundary and changes a shared C struct (`NSC_Size`), so header/ABI mismatches or memory-layout assumptions could break consumers despite relatively small functional scope.
> 
> **Overview**
> Adds native 3D flattening support to the `NumSwiftC` bridge for both `Float` and `Float16`, extending `NSC_Size` with a `depth` field and wiring new C entrypoints `nsc_flatten3d`/`nsc_flatten3d_16` to produce contiguous buffers from `[[[T]]]`.
> 
> Updates Swift `flatten()` APIs: 2D `Array<[Float]>`/`Array<[Float16]>` now use pure-Swift `flatMap` and drop the optional `inputSize` parameter, while 3D arrays gain a `flatten()` convenience; several 3D arithmetic operators in `Float32.swift` are also tightened with `reserveCapacity` and simplified loops.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15aa589866302e8f9db0a05a864addb31352bd89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->