### PR TITLE
updated for 1d

### DIFF
--- a/Sources/NumSwift/BaseNumeric.swift
+++ b/Sources/NumSwift/BaseNumeric.swift
@@ -64,6 +64,84 @@ public extension Collection where Self.Iterator.Element: RandomAccessCollection 
 }
 
 
+public extension ContiguousArray {
+  var shape: [Int] {
+    return shapeOf
+  }
+  
+  func batched(into size: Int) -> [[Element]] {
+    return stride(from: 0, to: count, by: size).map {
+      Array(self[$0 ..< Swift.min($0 + size, count)])
+    }
+  }
+  
+  subscript(safe safeIndex: Int) -> Element? {
+    if safeIndex >= 0,
+       safeIndex < self.count {
+      return self[safeIndex]
+    }
+    
+    return nil
+  }
+  
+  subscript(safe safeIndex: Range<Int>, default: Element) -> Self {
+    let lowerBound = Swift.max(0, safeIndex.lowerBound)
+    let upperBound = Swift.min(self.count, safeIndex.upperBound)
+    
+    let expectedTotal = safeIndex.upperBound - safeIndex.lowerBound
+    let totalWeHave = upperBound - lowerBound
+    
+    var result = self[lowerBound..<upperBound]
+    
+    // this doesnt take into account negative indicies...
+    if totalWeHave < expectedTotal {
+      result.append(contentsOf: Array(repeating: `default`, count: expectedTotal - totalWeHave))
+    }
+        
+    return Self(result)
+  }
+  
+  func concurrentBatchedForEach(workers: Int,
+                                priority: DispatchQoS.QoSClass = .default,
+                                _ block: @escaping (_ elements: [Element],
+                                                    _ workerIndex: Int,
+                                                    _ indexRange: CountableRange<Int>,
+                                                    _ processingCount: Int,
+                                                    _ workerId: UUID) -> ()) {
+    
+    DispatchQueue.concurrentBatchedPerform(units: self.count,
+                                           workers: workers,
+                                           priority: priority) { range, workerIndex, count, workerId in
+      block(Array(self[range]), workerIndex, range, count, workerId)
+    }
+  }
+
+  func concurrentForEach(workers: Int, priority: DispatchQoS.QoSClass = .default, _ block: @escaping (_ element: Element, _ index: Int, _ processingCount: Int, _ workerId: UUID) -> ()) {
+    DispatchQueue.concurrentPerform(units: self.count, workers: workers, priority: priority) { i, count, workerId in
+      block(self[i], i, count, workerId)
+    }
+  }
+  
+  func concurrentForEach(workers: Int, priority: DispatchQoS.QoSClass = .default, _ block: @escaping (_ element: Element, _ index: Int) -> ()) {
+    DispatchQueue.concurrentPerform(units: self.count, workers: workers, priority: priority) { i in
+      block(self[i], i)
+    }
+  }
+  
+  func concurrentForEach(_ block: (_ element: Element, _ index: Int) -> ()) {
+    let group = DispatchGroup()
+
+    DispatchQueue.concurrentPerform(iterations: self.count) { i in
+      group.enter()
+      block(self[i], i)
+      group.leave()
+    }
+    
+    group.wait()
+  }
+  
+}
+
 public extension Array {
   
   var shape: [Int] {
@@ -83,6 +161,23 @@ public extension Array {
     }
     
     return nil
+  }
+  
+  subscript(safe safeIndex: Range<Int>, default: Element) -> Self {
+    let lowerBound = Swift.max(0, safeIndex.lowerBound)
+    let upperBound = Swift.min(self.count, safeIndex.upperBound)
+    
+    let expectedTotal = safeIndex.upperBound - safeIndex.lowerBound
+    let totalWeHave = upperBound - lowerBound
+    
+    var result = self[lowerBound..<upperBound]
+    
+    // this doesnt take into account negative indicies...
+    if totalWeHave < expectedTotal {
+      result.append(contentsOf: Array(repeating: `default`, count: expectedTotal - totalWeHave))
+    }
+        
+    return Self(result)
   }
   
   func concurrentBatchedForEach(workers: Int,

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -1035,7 +1035,7 @@ public enum NumSwiftFlat {
   /// Element-wise addition using vDSP_vadd
   public static func add(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
     guard a.count == b.count else {
-      assertionFailure("Array counts must match")
+      preconditionFailure("Array counts must match")
       return ContiguousArray<Float>()
     }
     
@@ -1054,7 +1054,7 @@ public enum NumSwiftFlat {
   /// Element-wise subtraction (a - b) using vDSP_vsub
   public static func subtract(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
     guard a.count == b.count else {
-      assertionFailure("Array counts must match")
+      preconditionFailure("Array counts must match")
       return ContiguousArray<Float>()
     }
 
@@ -1074,7 +1074,7 @@ public enum NumSwiftFlat {
   /// Element-wise multiplication using vDSP_vmul
   public static func multiply(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
     guard a.count == b.count else {
-      assertionFailure("Array counts must match")
+      preconditionFailure("Array counts must match")
       return ContiguousArray<Float>()
     }
     
@@ -1093,7 +1093,7 @@ public enum NumSwiftFlat {
   /// Element-wise division (a / b) using vDSP_vdiv
   public static func divide(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
     guard a.count == b.count else {
-      assertionFailure("Array counts must match")
+      preconditionFailure("Array counts must match")
       return ContiguousArray<Float>()
     }
     
@@ -1246,11 +1246,13 @@ public enum NumSwiftFlat {
   // MARK: - Matrix Transpose
   
   /// Transpose a single 2D matrix stored as flat row-major using vDSP_mtrans
+  /// rows: is the number of rows in the input matrix
+  /// columns: is the number of columns in the input matrix
   public static func transpose(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
     var c = ContiguousArray<Float>(repeating: 0, count: rows * columns)
     a.withUnsafeBufferPointer { aBuf in
       c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(rows), vDSP_Length(columns))
+        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(columns), vDSP_Length(rows))
       }
     }
     return c

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -661,6 +661,90 @@ public extension Array where Element == [[Float]] {
   }
 }
 
+public extension ContiguousArray {
+  subscript(safe safeIndex: Int, default: Element) -> Element {
+    if safeIndex < 0 {
+      return `default`
+    }
+    
+    return self[safe: safeIndex] ?? `default`
+  }
+  
+  subscript(_ multiple: [Int], default: Element) -> Self {
+    var result: Self = []
+    result.reserveCapacity(multiple.count)
+    
+    multiple.forEach { i in
+      result.append(self[safe: i, `default`])
+    }
+    
+    return result
+  }
+  
+  subscript(range multiple: Range<Int>, default: Element) -> Self {
+    var result: Self = []
+    result.reserveCapacity(multiple.count)
+    
+    multiple.forEach { i in
+      result.append(self[safe: i, `default`])
+    }
+    
+    return result
+  }
+
+  subscript(range multiple: Range<Int>, dialate: Int, default: Element) -> Self {
+    var result: Self = []
+    result.reserveCapacity(multiple.count)
+    
+    var i: Int = 0
+    var dialateTotal: Int = 0
+    
+    let range = [Int](multiple)
+
+    while i < multiple.count {
+      if i > 0 && dialateTotal < dialate {
+        result.append(self[safe: -1, `default`])
+        dialateTotal += 1
+      } else {
+        result.append(self[safe: range[i], `default`])
+        i += 1
+        dialateTotal = 0
+      }
+    }
+
+    return result
+  }
+  
+  subscript(range multiple: Range<Int>, padding: Int, dialate: Int, default: Element) -> Self {
+    var result: Self = []
+    //result.reserveCapacity(multiple.count)
+    
+    var i: Int = 0
+    var dialateTotal: Int = 0
+    var paddingTotal: Int = 0
+    
+    let range = [Int](multiple)
+    
+    while i < (multiple.count + padding * 4) {
+      if (i > multiple.count || i == 0) && paddingTotal < padding {
+        result.append(self[safe: -1, `default`])
+        paddingTotal += 1
+      } else if i > 0 && i < multiple.count && dialateTotal < dialate {
+        result.append(self[safe: -1, `default`])
+        dialateTotal += 1
+      } else {
+        if i < multiple.count {
+          result.append(self[safe: range[i], `default`])
+          paddingTotal = 0
+          dialateTotal = 0
+        }
+        i += 1
+      }
+    }
+
+    return result
+  }
+}
 
 public extension Array {
   func as3D() -> [[[Element]]] {
@@ -1024,639 +1108,3 @@ public extension Array where Element == [Float] {
   }
 }
 
-// MARK: - Flat Array Operations (Accelerate-backed)
-
-/// Provides high-performance flat-array operations on `ContiguousArray<Float>` using Apple's Accelerate framework.
-/// These avoid the overhead of nested `[[[Float]]]` arrays and enable direct SIMD/vectorized computation.
-public enum NumSwiftFlat {
-  
-  // MARK: - Element-wise Arithmetic (array + array)
-  
-  /// Element-wise addition using vDSP_vadd
-  /// we dont need count check here because if two arrays are different sizes we'll just add the number of elements in A
-  public static func add(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      b.withUnsafeBufferPointer { bBuf in
-        c.withUnsafeMutableBufferPointer { cBuf in
-          vDSP_vadd(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-        }
-      }
-    }
-    return c
-  }
-  
-  /// Element-wise subtraction (a - b) using vDSP_vsub
-  /// we dont need count check here because if two arrays are different sizes we'll just sub the number of elements in A
-  public static func subtract(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      b.withUnsafeBufferPointer { bBuf in
-        c.withUnsafeMutableBufferPointer { cBuf in
-          // vDSP_vsub computes C = B - A (note reversed order)
-          vDSP_vsub(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-        }
-      }
-    }
-    return c
-  }
-  
-  /// Element-wise multiplication using vDSP_vmul
-  /// we dont need count check here because if two arrays are different sizes we'll just multiply the number of elements in A
-  public static func multiply(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      b.withUnsafeBufferPointer { bBuf in
-        c.withUnsafeMutableBufferPointer { cBuf in
-          vDSP_vmul(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-        }
-      }
-    }
-    return c
-  }
-  
-  /// Element-wise division (a / b) using vDSP_vdiv
-  /// we dont need count check here because if two arrays are different sizes we'll just divide the number of elements in A
-  public static func divide(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      b.withUnsafeBufferPointer { bBuf in
-        c.withUnsafeMutableBufferPointer { cBuf in
-          // vDSP_vdiv computes C = B / A (note reversed order)
-          vDSP_vdiv(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-        }
-      }
-    }
-    return c
-  }
-  
-  // MARK: - Scalar Arithmetic (array op scalar)
-  
-  /// Add scalar to every element using vDSP_vsadd
-  public static func add(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
-    let count = a.count
-    var s = scalar
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_vsadd(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  /// Multiply every element by scalar using vDSP_vsmul
-  public static func multiply(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
-    let count = a.count
-    var s = scalar
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_vsmul(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  /// Divide every element by scalar using vDSP_vsdiv
-  public static func divide(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
-    let count = a.count
-    var s = scalar
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_vsdiv(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  /// Subtract scalar from every element: result = a - scalar
-  public static func subtract(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
-    return add(a, scalar: -scalar)
-  }
-  
-  /// Scalar minus every element: result = scalar - a. Uses vDSP_vneg + vDSP_vsadd.
-  public static func subtract(scalar: Float, _ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    var s = scalar
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        // negate a
-        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-        // add scalar
-        vDSP_vsadd(cBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  /// Scalar divided by every element: result = scalar / a[i]
-  public static func divide(scalar: Float, _ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var s = scalar
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_svdiv(&s, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  // MARK: - Negation
-  
-  /// Negate every element using vDSP_vneg
-  public static func negate(_ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  // MARK: - Reductions
-  
-  /// Sum of all elements using vDSP_sve
-  public static func sum(_ a: ContiguousArray<Float>) -> Float {
-    var result: Float = 0
-    a.withUnsafeBufferPointer { aBuf in
-      vDSP_sve(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
-    }
-    return result
-  }
-  
-  /// Sum of squares using vDSP_svesq
-  public static func sumOfSquares(_ a: ContiguousArray<Float>) -> Float {
-    var result: Float = 0
-    a.withUnsafeBufferPointer { aBuf in
-      vDSP_svesq(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
-    }
-    return result
-  }
-  
-  /// Mean of all elements using vDSP_meanv
-  public static func mean(_ a: ContiguousArray<Float>) -> Float {
-    var result: Float = 0
-    a.withUnsafeBufferPointer { aBuf in
-      vDSP_meanv(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
-    }
-    return result
-  }
-  
-  // MARK: - Square Root
-  
-  /// Element-wise square root using vForce
-  public static func sqrt(_ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    let count = a.count
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        var n = Int32(count)
-        vvsqrtf(cBuf.baseAddress!, aBuf.baseAddress!, &n)
-      }
-    }
-    return c
-  }
-  
-  // MARK: - Matrix Transpose
-  
-  /// Transpose a single 2D matrix stored as flat row-major using vDSP_mtrans
-  /// rows: is the number of rows in the input matrix
-  /// columns: is the number of columns in the input matrix
-  public static func transpose(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
-    var c = ContiguousArray<Float>(repeating: 0, count: rows * columns)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(columns), vDSP_Length(rows))
-      }
-    }
-    return c
-  }
-  
-  // MARK: - Matrix Multiplication
-  
-  /// Performs matrix multiplication on flat [Float] using Accelerate's vDSP_mmul.
-  public static func matmul(_ a: [Float],
-                            _ b: [Float],
-                            aRows: Int,
-                            aCols: Int,
-                            bRows: Int,
-                            bCols: Int) -> [Float] {
-    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = [Float](repeating: 0, count: aRows * bCols)
-    
-    vDSP_mmul(a, 1,
-              b, 1,
-              &c, 1,
-              vDSP_Length(aRows),
-              vDSP_Length(bCols),
-              vDSP_Length(aCols))
-    
-    return c
-  }
-  
-  /// Performs matrix multiplication on flat ContiguousArray<Float> using Accelerate's vDSP_mmul.
-  public static func matmul(_ a: ContiguousArray<Float>,
-                            _ b: ContiguousArray<Float>,
-                            aRows: Int,
-                            aCols: Int,
-                            bRows: Int,
-                            bCols: Int) -> ContiguousArray<Float> {
-    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = ContiguousArray<Float>(repeating: 0, count: aRows * bCols)
-    
-    a.withUnsafeBufferPointer { aBuf in
-      b.withUnsafeBufferPointer { bBuf in
-        c.withUnsafeMutableBufferPointer { cBuf in
-          vDSP_mmul(aBuf.baseAddress!, 1,
-                    bBuf.baseAddress!, 1,
-                    cBuf.baseAddress!, 1,
-                    vDSP_Length(aRows),
-                    vDSP_Length(bCols),
-                    vDSP_Length(aCols))
-        }
-      }
-    }
-    
-    return c
-  }
-  
-  // MARK: - Clip
-  
-  /// Clip all values to [-limit, limit] using vDSP_vclip
-  public static func clip(_ a: ContiguousArray<Float>, to limit: Float) -> ContiguousArray<Float> {
-    let count = a.count
-    var low = -limit
-    var high = limit
-    var c = ContiguousArray<Float>(repeating: 0, count: count)
-    a.withUnsafeBufferPointer { aBuf in
-      c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_vclip(aBuf.baseAddress!, 1, &low, &high, cBuf.baseAddress!, 1, vDSP_Length(count))
-      }
-    }
-    return c
-  }
-  
-  // MARK: - Float16 Support
-  
-  // MARK: - Convolution (flat row-major)
-  
-  /// 2D convolution on flat row-major arrays via the C `nsc_conv1d` function.
-  public static func conv2d(signal: ContiguousArray<Float>,
-                            filter: ContiguousArray<Float>,
-                            strides: (Int, Int) = (1,1),
-                            padding: NumSwift.ConvPadding = .valid,
-                            filterSize: (rows: Int, columns: Int),
-                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    let result = NumSwiftC.conv1d(signal: Array(signal),
-                                  filter: Array(filter),
-                                  strides: strides,
-                                  padding: padding,
-                                  filterSize: filterSize,
-                                  inputSize: inputSize)
-    return ContiguousArray(result)
-  }
-  
-  /// Transposed 2D convolution on flat row-major arrays via the C `nsc_transConv1d` function.
-  public static func transConv2d(signal: ContiguousArray<Float>,
-                                 filter: ContiguousArray<Float>,
-                                 strides: (Int, Int) = (1,1),
-                                 padding: NumSwift.ConvPadding = .valid,
-                                 filterSize: (rows: Int, columns: Int),
-                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    let result = NumSwiftC.transConv1d(signal: Array(signal),
-                                       filter: Array(filter),
-                                       strides: strides,
-                                       padding: padding,
-                                       filterSize: filterSize,
-                                       inputSize: inputSize)
-    return ContiguousArray(result)
-  }
-  
-  /// Zero-pad a flat row-major 2D array with explicit padding values.
-  public static func zeroPad(signal: ContiguousArray<Float>,
-                             padding: NumSwiftPadding,
-                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
-      return signal
-    }
-    
-    let expectedRows = inputSize.rows + padding.top + padding.bottom
-    let expectedColumns = inputSize.columns + padding.left + padding.right
-    var result = ContiguousArray<Float>(repeating: 0, count: expectedRows * expectedColumns)
-    
-    // Copy original data into the padded result at the correct offsets
-    for r in 0..<inputSize.rows {
-      for c in 0..<inputSize.columns {
-        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
-      }
-    }
-    
-    return result
-  }
-  
-  /// Zero-pad a flat row-major 2D array computed from filter/input sizes.
-  public static func zeroPad(signal: ContiguousArray<Float>,
-                             filterSize: (rows: Int, columns: Int),
-                             inputSize: (rows: Int, columns: Int),
-                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float> {
-    let result = NumSwiftC.zeroPad(signal: Array(signal),
-                                   filterSize: filterSize,
-                                   inputSize: inputSize,
-                                   stride: stride)
-    return ContiguousArray(result)
-  }
-  
-  /// Stride-pad a flat row-major 2D array (inserts zeros between elements).
-  /// Places original values at stride intervals in a larger zero-filled output.
-  public static func stridePad(signal: ContiguousArray<Float>,
-                               strides: (rows: Int, columns: Int),
-                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
-    
-    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
-    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
-    var result = ContiguousArray<Float>(repeating: 0, count: newRows * newColumns)
-    
-    for r in 0..<inputSize.rows {
-      for c in 0..<inputSize.columns {
-        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
-      }
-    }
-    
-    return result
-  }
-  
-  /// Returns the shape of a stride-padded result without actually padding.
-  public static func stridePadShape(inputSize: (rows: Int, columns: Int),
-                                    strides: (rows: Int, columns: Int)) -> (rows: Int, columns: Int) {
-    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
-    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
-    return (newRows, newColumns)
-  }
-  
-  /// Flip a flat row-major 2D matrix 180 degrees (reverse all elements, then reverse each row).
-  /// Equivalent to reversing the entire array then reversing each row segment.
-  public static func flip180(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
-    var result = ContiguousArray<Float>(repeating: 0, count: a.count)
-    // flip180 = reverse rows, then reverse each row's columns
-    for r in 0..<rows {
-      let srcRow = rows - 1 - r
-      let srcStart = srcRow * columns
-      let dstStart = r * columns
-      for c in 0..<columns {
-        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
-      }
-    }
-    return result
-  }
-  
-  /// Padding calculation utility (delegates to NumSwiftC).
-  public static func paddingCalculation(strides: (Int, Int) = (1,1),
-                                        padding: NumSwift.ConvPadding = .valid,
-                                        filterSize: (rows: Int, columns: Int),
-                                        inputSize: (rows: Int, columns: Int)) -> (top: Int, bottom: Int, left: Int, right: Int) {
-    return NumSwiftC.paddingCalculation(strides: strides, padding: padding, filterSize: filterSize, inputSize: inputSize)
-  }
-  
-  #if arch(arm64)
-  // Float16 versions use manual loops (no Accelerate support for Float16).
-  // The compiler can auto-vectorize these for ARM NEON.
-  
-  public static func add(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] + b[i] }
-    return c
-  }
-  
-  public static func subtract(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] - b[i] }
-    return c
-  }
-  
-  public static func multiply(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] * b[i] }
-    return c
-  }
-  
-  public static func divide(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] / b[i] }
-    return c
-  }
-  
-  public static func add(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] + scalar }
-    return c
-  }
-  
-  public static func multiply(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] * scalar }
-    return c
-  }
-  
-  public static func divide(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = a[i] / scalar }
-    return c
-  }
-  
-  public static func subtract(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
-    return add(a, scalar: -scalar)
-  }
-  
-  public static func subtract(scalar: Float16, _ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = scalar - a[i] }
-    return c
-  }
-  
-  public static func divide(scalar: Float16, _ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = scalar / a[i] }
-    return c
-  }
-  
-  public static func negate(_ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = -a[i] }
-    return c
-  }
-  
-  public static func sum(_ a: ContiguousArray<Float16>) -> Float16 {
-    var result: Float16 = 0
-    for i in 0..<a.count { result += a[i] }
-    return result
-  }
-  
-  public static func sumOfSquares(_ a: ContiguousArray<Float16>) -> Float16 {
-    var result: Float16 = 0
-    for i in 0..<a.count { result += a[i] * a[i] }
-    return result
-  }
-  
-  public static func mean(_ a: ContiguousArray<Float16>) -> Float16 {
-    guard !a.isEmpty else { return 0 }
-    return sum(a) / Float16(a.count)
-  }
-  
-  public static func sqrt(_ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = Float16(Foundation.sqrt(Float(a[i]))) }
-    return c
-  }
-  
-  public static func transpose(_ a: ContiguousArray<Float16>, rows: Int, columns: Int) -> ContiguousArray<Float16> {
-    var c = ContiguousArray<Float16>(repeating: 0, count: rows * columns)
-    for r in 0..<rows {
-      for col in 0..<columns {
-        c[col * rows + r] = a[r * columns + col]
-      }
-    }
-    return c
-  }
-  
-  public static func clip(_ a: ContiguousArray<Float16>, to limit: Float16) -> ContiguousArray<Float16> {
-    let count = a.count
-    var c = ContiguousArray<Float16>(repeating: 0, count: count)
-    for i in 0..<count { c[i] = Swift.max(-limit, Swift.min(limit, a[i])) }
-    return c
-  }
-  
-  public static func matmul(_ a: ContiguousArray<Float16>,
-                            _ b: ContiguousArray<Float16>,
-                            aRows: Int,
-                            aCols: Int,
-                            bRows: Int,
-                            bCols: Int) -> ContiguousArray<Float16> {
-    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = ContiguousArray<Float16>(repeating: 0, count: aRows * bCols)
-    
-    for i in 0..<aRows {
-      for j in 0..<bCols {
-        var sum: Float16 = 0
-        for k in 0..<aCols {
-          sum += a[i * aCols + k] * b[k * bCols + j]
-        }
-        c[i * bCols + j] = sum
-      }
-    }
-    
-    return c
-  }
-  
-  // MARK: - Float16 Convolution / Padding
-  
-  public static func conv2d(signal: ContiguousArray<Float16>,
-                            filter: ContiguousArray<Float16>,
-                            strides: (Int, Int) = (1,1),
-                            padding: NumSwift.ConvPadding = .valid,
-                            filterSize: (rows: Int, columns: Int),
-                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    let result = NumSwiftC.conv1d(signal: Array(signal),
-                                  filter: Array(filter),
-                                  strides: strides,
-                                  padding: padding,
-                                  filterSize: filterSize,
-                                  inputSize: inputSize)
-    return ContiguousArray(result)
-  }
-  
-  public static func transConv2d(signal: ContiguousArray<Float16>,
-                                 filter: ContiguousArray<Float16>,
-                                 strides: (Int, Int) = (1,1),
-                                 padding: NumSwift.ConvPadding = .valid,
-                                 filterSize: (rows: Int, columns: Int),
-                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    let result = NumSwiftC.transConv1d(signal: Array(signal),
-                                       filter: Array(filter),
-                                       strides: strides,
-                                       padding: padding,
-                                       filterSize: filterSize,
-                                       inputSize: inputSize)
-    return ContiguousArray(result)
-  }
-  
-  public static func zeroPad(signal: ContiguousArray<Float16>,
-                             padding: NumSwiftPadding,
-                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
-      return signal
-    }
-    // No flat C function for Float16 specific_zero_pad; do it in Swift
-    let expectedRows = inputSize.rows + padding.top + padding.bottom
-    let expectedColumns = inputSize.columns + padding.left + padding.right
-    var result = ContiguousArray<Float16>(repeating: 0, count: expectedRows * expectedColumns)
-    for r in 0..<inputSize.rows {
-      for c in 0..<inputSize.columns {
-        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
-      }
-    }
-    return result
-  }
-  
-  public static func zeroPad(signal: ContiguousArray<Float16>,
-                             filterSize: (rows: Int, columns: Int),
-                             inputSize: (rows: Int, columns: Int),
-                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float16> {
-    let padding = NumSwiftC.paddingCalculation(strides: stride, padding: .same, filterSize: filterSize, inputSize: inputSize)
-    let numPadding = NumSwiftPadding(top: padding.top, left: padding.left, right: padding.right, bottom: padding.bottom)
-    return zeroPad(signal: signal, padding: numPadding, inputSize: inputSize)
-  }
-  
-  public static func stridePad(signal: ContiguousArray<Float16>,
-                               strides: (rows: Int, columns: Int),
-                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
-    
-    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
-    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
-    var result = ContiguousArray<Float16>(repeating: 0, count: newRows * newColumns)
-    
-    for r in 0..<inputSize.rows {
-      for c in 0..<inputSize.columns {
-        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
-      }
-    }
-    
-    return result
-  }
-  
-  public static func flip180(_ a: ContiguousArray<Float16>, rows: Int, columns: Int) -> ContiguousArray<Float16> {
-    var result = ContiguousArray<Float16>(repeating: 0, count: a.count)
-    for r in 0..<rows {
-      let srcRow = rows - 1 - r
-      let srcStart = srcRow * columns
-      let dstStart = r * columns
-      for c in 0..<columns {
-        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
-      }
-    }
-    return result
-  }
-  #endif
-}

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -1023,3 +1023,634 @@ public extension Array where Element == [Float] {
     return result
   }
 }
+
+// MARK: - Flat Array Operations (Accelerate-backed)
+
+/// Provides high-performance flat-array operations on `ContiguousArray<Float>` using Apple's Accelerate framework.
+/// These avoid the overhead of nested `[[[Float]]]` arrays and enable direct SIMD/vectorized computation.
+public enum NumSwiftFlat {
+  
+  // MARK: - Element-wise Arithmetic (array + array)
+  
+  /// Element-wise addition using vDSP_vadd
+  public static func add(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_vadd(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise subtraction (a - b) using vDSP_vsub
+  public static func subtract(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          // vDSP_vsub computes C = B - A (note reversed order)
+          vDSP_vsub(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise multiplication using vDSP_vmul
+  public static func multiply(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_vmul(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise division (a / b) using vDSP_vdiv
+  public static func divide(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          // vDSP_vdiv computes C = B / A (note reversed order)
+          vDSP_vdiv(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Scalar Arithmetic (array op scalar)
+  
+  /// Add scalar to every element using vDSP_vsadd
+  public static func add(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsadd(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Multiply every element by scalar using vDSP_vsmul
+  public static func multiply(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsmul(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Divide every element by scalar using vDSP_vsdiv
+  public static func divide(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsdiv(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Subtract scalar from every element: result = a - scalar
+  public static func subtract(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    return add(a, scalar: -scalar)
+  }
+  
+  /// Scalar minus every element: result = scalar - a. Uses vDSP_vneg + vDSP_vsadd.
+  public static func subtract(scalar: Float, _ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    var s = scalar
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        // negate a
+        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        // add scalar
+        vDSP_vsadd(cBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Scalar divided by every element: result = scalar / a[i]
+  public static func divide(scalar: Float, _ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_svdiv(&s, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Negation
+  
+  /// Negate every element using vDSP_vneg
+  public static func negate(_ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Reductions
+  
+  /// Sum of all elements using vDSP_sve
+  public static func sum(_ a: ContiguousArray<Float>) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_sve(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  /// Sum of squares using vDSP_svesq
+  public static func sumOfSquares(_ a: ContiguousArray<Float>) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_svesq(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  /// Mean of all elements using vDSP_meanv
+  public static func mean(_ a: ContiguousArray<Float>) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_meanv(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  // MARK: - Square Root
+  
+  /// Element-wise square root using vForce
+  public static func sqrt(_ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        var n = Int32(count)
+        vvsqrtf(cBuf.baseAddress!, aBuf.baseAddress!, &n)
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Matrix Transpose
+  
+  /// Transpose a single 2D matrix stored as flat row-major using vDSP_mtrans
+  public static func transpose(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
+    var c = ContiguousArray<Float>(repeating: 0, count: rows * columns)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(columns), vDSP_Length(rows))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Matrix Multiplication
+  
+  /// Performs matrix multiplication on flat [Float] using Accelerate's vDSP_mmul.
+  public static func matmul(_ a: [Float],
+                            _ b: [Float],
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> [Float] {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = [Float](repeating: 0, count: aRows * bCols)
+    
+    vDSP_mmul(a, 1,
+              b, 1,
+              &c, 1,
+              vDSP_Length(aRows),
+              vDSP_Length(bCols),
+              vDSP_Length(aCols))
+    
+    return c
+  }
+  
+  /// Performs matrix multiplication on flat ContiguousArray<Float> using Accelerate's vDSP_mmul.
+  public static func matmul(_ a: ContiguousArray<Float>,
+                            _ b: ContiguousArray<Float>,
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> ContiguousArray<Float> {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = ContiguousArray<Float>(repeating: 0, count: aRows * bCols)
+    
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_mmul(aBuf.baseAddress!, 1,
+                    bBuf.baseAddress!, 1,
+                    cBuf.baseAddress!, 1,
+                    vDSP_Length(aRows),
+                    vDSP_Length(bCols),
+                    vDSP_Length(aCols))
+        }
+      }
+    }
+    
+    return c
+  }
+  
+  // MARK: - Clip
+  
+  /// Clip all values to [-limit, limit] using vDSP_vclip
+  public static func clip(_ a: ContiguousArray<Float>, to limit: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var low = -limit
+    var high = limit
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vclip(aBuf.baseAddress!, 1, &low, &high, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Float16 Support
+  
+  // MARK: - Convolution (flat row-major)
+  
+  /// 2D convolution on flat row-major arrays via the C `nsc_conv1d` function.
+  public static func conv2d(signal: ContiguousArray<Float>,
+                            filter: ContiguousArray<Float>,
+                            strides: (Int, Int) = (1,1),
+                            padding: NumSwift.ConvPadding = .valid,
+                            filterSize: (rows: Int, columns: Int),
+                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  /// Transposed 2D convolution on flat row-major arrays via the C `nsc_transConv1d` function.
+  public static func transConv2d(signal: ContiguousArray<Float>,
+                                 filter: ContiguousArray<Float>,
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  /// Zero-pad a flat row-major 2D array with explicit padding values.
+  public static func zeroPad(signal: ContiguousArray<Float>,
+                             padding: NumSwiftPadding,
+                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
+      return signal
+    }
+    
+    let expectedRows = inputSize.rows + padding.top + padding.bottom
+    let expectedColumns = inputSize.columns + padding.left + padding.right
+    var result = ContiguousArray<Float>(repeating: 0, count: expectedRows * expectedColumns)
+    
+    // Copy original data into the padded result at the correct offsets
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  /// Zero-pad a flat row-major 2D array computed from filter/input sizes.
+  public static func zeroPad(signal: ContiguousArray<Float>,
+                             filterSize: (rows: Int, columns: Int),
+                             inputSize: (rows: Int, columns: Int),
+                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float> {
+    let result = NumSwiftC.zeroPad(signal: Array(signal),
+                                   filterSize: filterSize,
+                                   inputSize: inputSize,
+                                   stride: stride)
+    return ContiguousArray(result)
+  }
+  
+  /// Stride-pad a flat row-major 2D array (inserts zeros between elements).
+  /// Places original values at stride intervals in a larger zero-filled output.
+  public static func stridePad(signal: ContiguousArray<Float>,
+                               strides: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
+    
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    var result = ContiguousArray<Float>(repeating: 0, count: newRows * newColumns)
+    
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  /// Returns the shape of a stride-padded result without actually padding.
+  public static func stridePadShape(inputSize: (rows: Int, columns: Int),
+                                    strides: (rows: Int, columns: Int)) -> (rows: Int, columns: Int) {
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    return (newRows, newColumns)
+  }
+  
+  /// Flip a flat row-major 2D matrix 180 degrees (reverse all elements, then reverse each row).
+  /// Equivalent to reversing the entire array then reversing each row segment.
+  public static func flip180(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
+    var result = ContiguousArray<Float>(repeating: 0, count: a.count)
+    // flip180 = reverse rows, then reverse each row's columns
+    for r in 0..<rows {
+      let srcRow = rows - 1 - r
+      let srcStart = srcRow * columns
+      let dstStart = r * columns
+      for c in 0..<columns {
+        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
+      }
+    }
+    return result
+  }
+  
+  /// Padding calculation utility (delegates to NumSwiftC).
+  public static func paddingCalculation(strides: (Int, Int) = (1,1),
+                                        padding: NumSwift.ConvPadding = .valid,
+                                        filterSize: (rows: Int, columns: Int),
+                                        inputSize: (rows: Int, columns: Int)) -> (top: Int, bottom: Int, left: Int, right: Int) {
+    return NumSwiftC.paddingCalculation(strides: strides, padding: padding, filterSize: filterSize, inputSize: inputSize)
+  }
+  
+  #if arch(arm64)
+  // Float16 versions use manual loops (no Accelerate support for Float16).
+  // The compiler can auto-vectorize these for ARM NEON.
+  
+  public static func add(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] + b[i] }
+    return c
+  }
+  
+  public static func subtract(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] - b[i] }
+    return c
+  }
+  
+  public static func multiply(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] * b[i] }
+    return c
+  }
+  
+  public static func divide(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] / b[i] }
+    return c
+  }
+  
+  public static func add(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] + scalar }
+    return c
+  }
+  
+  public static func multiply(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] * scalar }
+    return c
+  }
+  
+  public static func divide(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] / scalar }
+    return c
+  }
+  
+  public static func subtract(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    return add(a, scalar: -scalar)
+  }
+  
+  public static func subtract(scalar: Float16, _ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = scalar - a[i] }
+    return c
+  }
+  
+  public static func divide(scalar: Float16, _ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = scalar / a[i] }
+    return c
+  }
+  
+  public static func negate(_ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = -a[i] }
+    return c
+  }
+  
+  public static func sum(_ a: ContiguousArray<Float16>) -> Float16 {
+    var result: Float16 = 0
+    for i in 0..<a.count { result += a[i] }
+    return result
+  }
+  
+  public static func sumOfSquares(_ a: ContiguousArray<Float16>) -> Float16 {
+    var result: Float16 = 0
+    for i in 0..<a.count { result += a[i] * a[i] }
+    return result
+  }
+  
+  public static func mean(_ a: ContiguousArray<Float16>) -> Float16 {
+    guard !a.isEmpty else { return 0 }
+    return sum(a) / Float16(a.count)
+  }
+  
+  public static func sqrt(_ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = Float16(Foundation.sqrt(Float(a[i]))) }
+    return c
+  }
+  
+  public static func transpose(_ a: ContiguousArray<Float16>, rows: Int, columns: Int) -> ContiguousArray<Float16> {
+    var c = ContiguousArray<Float16>(repeating: 0, count: rows * columns)
+    for r in 0..<rows {
+      for col in 0..<columns {
+        c[col * rows + r] = a[r * columns + col]
+      }
+    }
+    return c
+  }
+  
+  public static func clip(_ a: ContiguousArray<Float16>, to limit: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = Swift.max(-limit, Swift.min(limit, a[i])) }
+    return c
+  }
+  
+  public static func matmul(_ a: ContiguousArray<Float16>,
+                            _ b: ContiguousArray<Float16>,
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> ContiguousArray<Float16> {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = ContiguousArray<Float16>(repeating: 0, count: aRows * bCols)
+    
+    for i in 0..<aRows {
+      for j in 0..<bCols {
+        var sum: Float16 = 0
+        for k in 0..<aCols {
+          sum += a[i * aCols + k] * b[k * bCols + j]
+        }
+        c[i * bCols + j] = sum
+      }
+    }
+    
+    return c
+  }
+  
+  // MARK: - Float16 Convolution / Padding
+  
+  public static func conv2d(signal: ContiguousArray<Float16>,
+                            filter: ContiguousArray<Float16>,
+                            strides: (Int, Int) = (1,1),
+                            padding: NumSwift.ConvPadding = .valid,
+                            filterSize: (rows: Int, columns: Int),
+                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  public static func transConv2d(signal: ContiguousArray<Float16>,
+                                 filter: ContiguousArray<Float16>,
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  public static func zeroPad(signal: ContiguousArray<Float16>,
+                             padding: NumSwiftPadding,
+                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
+      return signal
+    }
+    // No flat C function for Float16 specific_zero_pad; do it in Swift
+    let expectedRows = inputSize.rows + padding.top + padding.bottom
+    let expectedColumns = inputSize.columns + padding.left + padding.right
+    var result = ContiguousArray<Float16>(repeating: 0, count: expectedRows * expectedColumns)
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
+      }
+    }
+    return result
+  }
+  
+  public static func zeroPad(signal: ContiguousArray<Float16>,
+                             filterSize: (rows: Int, columns: Int),
+                             inputSize: (rows: Int, columns: Int),
+                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float16> {
+    let padding = NumSwiftC.paddingCalculation(strides: stride, padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let numPadding = NumSwiftPadding(top: padding.top, left: padding.left, right: padding.right, bottom: padding.bottom)
+    return zeroPad(signal: signal, padding: numPadding, inputSize: inputSize)
+  }
+  
+  public static func stridePad(signal: ContiguousArray<Float16>,
+                               strides: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
+    
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    var result = ContiguousArray<Float16>(repeating: 0, count: newRows * newColumns)
+    
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  public static func flip180(_ a: ContiguousArray<Float16>, rows: Int, columns: Int) -> ContiguousArray<Float16> {
+    var result = ContiguousArray<Float16>(repeating: 0, count: a.count)
+    for r in 0..<rows {
+      let srcRow = rows - 1 - r
+      let srcStart = srcRow * columns
+      let dstStart = r * columns
+      for c in 0..<columns {
+        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
+      }
+    }
+    return result
+  }
+  #endif
+}

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -1034,6 +1034,11 @@ public enum NumSwiftFlat {
   
   /// Element-wise addition using vDSP_vadd
   public static func add(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    guard a.count == b.count else {
+      assertionFailure("Array counts must match")
+      return ContiguousArray<Float>()
+    }
+    
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1048,6 +1053,11 @@ public enum NumSwiftFlat {
   
   /// Element-wise subtraction (a - b) using vDSP_vsub
   public static func subtract(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    guard a.count == b.count else {
+      assertionFailure("Array counts must match")
+      return ContiguousArray<Float>()
+    }
+
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1063,6 +1073,11 @@ public enum NumSwiftFlat {
   
   /// Element-wise multiplication using vDSP_vmul
   public static func multiply(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    guard a.count == b.count else {
+      assertionFailure("Array counts must match")
+      return ContiguousArray<Float>()
+    }
+    
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1077,6 +1092,11 @@ public enum NumSwiftFlat {
   
   /// Element-wise division (a / b) using vDSP_vdiv
   public static func divide(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    guard a.count == b.count else {
+      assertionFailure("Array counts must match")
+      return ContiguousArray<Float>()
+    }
+    
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1230,7 +1250,7 @@ public enum NumSwiftFlat {
     var c = ContiguousArray<Float>(repeating: 0, count: rows * columns)
     a.withUnsafeBufferPointer { aBuf in
       c.withUnsafeMutableBufferPointer { cBuf in
-        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(columns), vDSP_Length(rows))
+        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(rows), vDSP_Length(columns))
       }
     }
     return c

--- a/Sources/NumSwift/Float32.swift
+++ b/Sources/NumSwift/Float32.swift
@@ -1033,12 +1033,8 @@ public enum NumSwiftFlat {
   // MARK: - Element-wise Arithmetic (array + array)
   
   /// Element-wise addition using vDSP_vadd
+  /// we dont need count check here because if two arrays are different sizes we'll just add the number of elements in A
   public static func add(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    guard a.count == b.count else {
-      preconditionFailure("Array counts must match")
-      return ContiguousArray<Float>()
-    }
-    
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1052,12 +1048,8 @@ public enum NumSwiftFlat {
   }
   
   /// Element-wise subtraction (a - b) using vDSP_vsub
+  /// we dont need count check here because if two arrays are different sizes we'll just sub the number of elements in A
   public static func subtract(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    guard a.count == b.count else {
-      preconditionFailure("Array counts must match")
-      return ContiguousArray<Float>()
-    }
-
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1072,12 +1064,8 @@ public enum NumSwiftFlat {
   }
   
   /// Element-wise multiplication using vDSP_vmul
+  /// we dont need count check here because if two arrays are different sizes we'll just multiply the number of elements in A
   public static func multiply(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    guard a.count == b.count else {
-      preconditionFailure("Array counts must match")
-      return ContiguousArray<Float>()
-    }
-    
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in
@@ -1091,12 +1079,8 @@ public enum NumSwiftFlat {
   }
   
   /// Element-wise division (a / b) using vDSP_vdiv
+  /// we dont need count check here because if two arrays are different sizes we'll just divide the number of elements in A
   public static func divide(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
-    guard a.count == b.count else {
-      preconditionFailure("Array counts must match")
-      return ContiguousArray<Float>()
-    }
-    
     let count = a.count
     var c = ContiguousArray<Float>(repeating: 0, count: count)
     a.withUnsafeBufferPointer { aBuf in

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
@@ -365,6 +365,22 @@ public struct NumSwiftC {
     return result
   }
 
+  public static func matmul1d(_ a: [Float],
+                            b: [Float],
+                            aSize: (rows: Int, columns: Int),
+                            bSize: (rows: Int, columns: Int)) -> [Float] {
+    
+    var results: [Float] = [Float](repeating: 0, count: aSize.rows * bSize.columns)
+    
+    nsc_matmul1d(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                 .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                 a,
+                 b,
+                 &results)
+    
+    return results
+  }
+  
   public static func matmul(_ a: [[Float]],
                             b: [[Float]],
                             aSize: (rows: Int, columns: Int),

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
@@ -332,6 +332,23 @@ public extension NumSwiftC {
     return result
   }
   
+  public static func matmul1d(_ a: [Float16],
+                              b: [Float16],
+                              aSize: (rows: Int, columns: Int),
+                              bSize: (rows: Int, columns: Int)) -> [Float16] {
+    
+    var results: [Float16] = [Float16](repeating: 0, count: aSize.rows * bSize.columns)
+    
+    nsc_matmul1d_16(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                    .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                    a,
+                    b,
+                    &results)
+    
+    return results
+  }
+  
+  
   static func matmul(_ a: [[Float16]],
                             b: [[Float16]],
                             aSize: (rows: Int, columns: Int),

--- a/Sources/NumSwift/NumSwiftFlat.swift
+++ b/Sources/NumSwift/NumSwiftFlat.swift
@@ -1,0 +1,1219 @@
+//
+//  NumSwiftFlat.swift
+//  NumSwift
+//
+//  Created by William Vabrinskas on 2/6/26.
+//
+
+import Accelerate
+import Foundation
+
+// MARK: - Flat Array Operations (Accelerate-backed)
+
+/// Provides high-performance flat-array operations on `[Float]` using Apple's Accelerate framework.
+/// These avoid the overhead of nested `[[[Float]]]` arrays and enable direct SIMD/vectorized computation.
+public enum NumSwiftFlat  {
+  
+  // MARK: - Element-wise Arithmetic (array + array)
+  
+  /// Element-wise addition using vDSP_vadd
+  /// we dont need count check here because if two arrays are different sizes we'll just add the number of elements in A
+  public static func add(_ a: [Float], _ b: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_vadd(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise subtraction (a - b) using vDSP_vsub
+  /// we dont need count check here because if two arrays are different sizes we'll just sub the number of elements in A
+  public static func subtract(_ a: [Float], _ b: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          // vDSP_vsub computes C = B - A (note reversed order)
+          vDSP_vsub(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise multiplication using vDSP_vmul
+  /// we dont need count check here because if two arrays are different sizes we'll just multiply the number of elements in A
+  public static func multiply(_ a: [Float], _ b: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_vmul(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise division (a / b) using vDSP_vdiv
+  /// we dont need count check here because if two arrays are different sizes we'll just divide the number of elements in A
+  public static func divide(_ a: [Float], _ b: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          // vDSP_vdiv computes C = B / A (note reversed order)
+          vDSP_vdiv(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Scalar Arithmetic (array op scalar)
+  
+  /// Add scalar to every element using vDSP_vsadd
+  public static func add(_ a: [Float], scalar: Float) -> [Float] {
+    let count = a.count
+    var s = scalar
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsadd(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Multiply every element by scalar using vDSP_vsmul
+  public static func multiply(_ a: [Float], scalar: Float) -> [Float] {
+    let count = a.count
+    var s = scalar
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsmul(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Divide every element by scalar using vDSP_vsdiv
+  public static func divide(_ a: [Float], scalar: Float) -> [Float] {
+    let count = a.count
+    var s = scalar
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsdiv(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Subtract scalar from every element: result = a - scalar
+  public static func subtract(_ a: [Float], scalar: Float) -> [Float] {
+    return add(a, scalar: -scalar)
+  }
+  
+  /// Scalar minus every element: result = scalar - a. Uses vDSP_vneg + vDSP_vsadd.
+  public static func subtract(scalar: Float, _ a: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    var s = scalar
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        // negate a
+        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        // add scalar
+        vDSP_vsadd(cBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Scalar divided by every element: result = scalar / a[i]
+  public static func divide(scalar: Float, _ a: [Float]) -> [Float] {
+    let count = a.count
+    var s = scalar
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_svdiv(&s, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Negation
+  
+  /// Negate every element using vDSP_vneg
+  public static func negate(_ a: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Reductions
+  
+  /// Sum of all elements using vDSP_sve
+  public static func sum(_ a: [Float]) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_sve(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  /// Sum of squares using vDSP_svesq
+  public static func sumOfSquares(_ a: [Float]) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_svesq(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  /// Mean of all elements using vDSP_meanv
+  public static func mean(_ a: [Float]) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_meanv(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  // MARK: - Square Root
+  
+  /// Element-wise square root using vForce
+  public static func sqrt(_ a: [Float]) -> [Float] {
+    let count = a.count
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        var n = Int32(count)
+        vvsqrtf(cBuf.baseAddress!, aBuf.baseAddress!, &n)
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Matrix Transpose
+  
+  /// Transpose a single 2D matrix stored as flat row-major using vDSP_mtrans
+  /// rows: is the number of rows in the input matrix
+  /// columns: is the number of columns in the input matrix
+  public static func transpose(_ a: [Float], rows: Int, columns: Int) -> [Float] {
+    var c = [Float](repeating: 0, count: rows * columns)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(columns), vDSP_Length(rows))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Matrix Multiplication
+  
+  /// Performs matrix multiplication on flat [Float] using Accelerate's vDSP_mmul.
+  public static func matmul(_ a: [Float],
+                            _ b: [Float],
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> [Float] {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = [Float](repeating: 0, count: aRows * bCols)
+    
+    vDSP_mmul(a, 1,
+              b, 1,
+              &c, 1,
+              vDSP_Length(aRows),
+              vDSP_Length(bCols),
+              vDSP_Length(aCols))
+    
+    return c
+  }
+  
+  // MARK: - Clip
+  
+  /// Clip all values to [-limit, limit] using vDSP_vclip
+  public static func clip(_ a: [Float], to limit: Float) -> [Float] {
+    let count = a.count
+    var low = -limit
+    var high = limit
+    var c = [Float](repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vclip(aBuf.baseAddress!, 1, &low, &high, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Float16 Support
+  
+  // MARK: - Convolution (flat row-major)
+  
+  /// 2D convolution on flat row-major arrays via the C `nsc_conv1d` function.
+  public static func conv2d(signal: [Float],
+                            filter: [Float],
+                            strides: (Int, Int) = (1,1),
+                            padding: NumSwift.ConvPadding = .valid,
+                            filterSize: (rows: Int, columns: Int),
+                            inputSize: (rows: Int, columns: Int)) -> [Float] {
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return result
+  }
+  
+  /// Transposed 2D convolution on flat row-major arrays via the C `nsc_transConv1d` function.
+  public static func transConv2d(signal: [Float],
+                                 filter: [Float],
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int)) -> [Float] {
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return result
+  }
+  
+  /// Zero-pad a flat row-major 2D array with explicit padding values.
+  public static func zeroPad(signal: [Float],
+                             padding: NumSwiftPadding,
+                             inputSize: (rows: Int, columns: Int)) -> [Float] {
+    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
+      return signal
+    }
+    
+    let expectedRows = inputSize.rows + padding.top + padding.bottom
+    let expectedColumns = inputSize.columns + padding.left + padding.right
+    var result = [Float](repeating: 0, count: expectedRows * expectedColumns)
+    
+    // Copy original data into the padded result at the correct offsets
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  /// Zero-pad a flat row-major 2D array computed from filter/input sizes.
+  public static func zeroPad(signal: [Float],
+                             filterSize: (rows: Int, columns: Int),
+                             inputSize: (rows: Int, columns: Int),
+                             stride: (Int, Int) = (1,1)) -> [Float] {
+    let result = NumSwiftC.zeroPad(signal: Array(signal),
+                                   filterSize: filterSize,
+                                   inputSize: inputSize,
+                                   stride: stride)
+    return result
+  }
+  
+  /// Stride-pad a flat row-major 2D array (inserts zeros between elements).
+  /// Places original values at stride intervals in a larger zero-filled output.
+  public static func stridePad(signal: [Float],
+                               strides: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int)) -> [Float] {
+    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
+    
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    var result = [Float](repeating: 0, count: newRows * newColumns)
+    
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  /// Returns the shape of a stride-padded result without actually padding.
+  public static func stridePadShape(inputSize: (rows: Int, columns: Int),
+                                    strides: (rows: Int, columns: Int)) -> (rows: Int, columns: Int) {
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    return (newRows, newColumns)
+  }
+  
+  /// Flip a flat row-major 2D matrix 180 degrees (reverse all elements, then reverse each row).
+  /// Equivalent to reversing the entire array then reversing each row segment.
+  public static func flip180(_ a: [Float], rows: Int, columns: Int) -> [Float] {
+    var result = [Float](repeating: 0, count: a.count)
+    // flip180 = reverse rows, then reverse each row's columns
+    for r in 0..<rows {
+      let srcRow = rows - 1 - r
+      let srcStart = srcRow * columns
+      let dstStart = r * columns
+      for c in 0..<columns {
+        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
+      }
+    }
+    return result
+  }
+  
+  /// Padding calculation utility (delegates to NumSwiftC).
+  public static func paddingCalculation(strides: (Int, Int) = (1,1),
+                                        padding: NumSwift.ConvPadding = .valid,
+                                        filterSize: (rows: Int, columns: Int),
+                                        inputSize: (rows: Int, columns: Int)) -> (top: Int, bottom: Int, left: Int, right: Int) {
+    return NumSwiftC.paddingCalculation(strides: strides, padding: padding, filterSize: filterSize, inputSize: inputSize)
+  }
+  
+  #if arch(arm64)
+  // Float16 versions use manual loops (no Accelerate support for Float16).
+  // The compiler can auto-vectorize these for ARM NEON.
+  
+  public static func add(_ a: [Float16], _ b: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] + b[i] }
+    return c
+  }
+  
+  public static func subtract(_ a: [Float16], _ b: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] - b[i] }
+    return c
+  }
+  
+  public static func multiply(_ a: [Float16], _ b: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] * b[i] }
+    return c
+  }
+  
+  public static func divide(_ a: [Float16], _ b: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] / b[i] }
+    return c
+  }
+  
+  public static func add(_ a: [Float16], scalar: Float16) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] + scalar }
+    return c
+  }
+  
+  public static func multiply(_ a: [Float16], scalar: Float16) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] * scalar }
+    return c
+  }
+  
+  public static func divide(_ a: [Float16], scalar: Float16) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] / scalar }
+    return c
+  }
+  
+  public static func subtract(_ a: [Float16], scalar: Float16) -> [Float16] {
+    return add(a, scalar: -scalar)
+  }
+  
+  public static func subtract(scalar: Float16, _ a: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = scalar - a[i] }
+    return c
+  }
+  
+  public static func divide(scalar: Float16, _ a: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = scalar / a[i] }
+    return c
+  }
+  
+  public static func negate(_ a: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = -a[i] }
+    return c
+  }
+  
+  public static func sum(_ a: [Float16]) -> Float16 {
+    var result: Float16 = 0
+    for i in 0..<a.count { result += a[i] }
+    return result
+  }
+  
+  public static func sumOfSquares(_ a: [Float16]) -> Float16 {
+    var result: Float16 = 0
+    for i in 0..<a.count { result += a[i] * a[i] }
+    return result
+  }
+  
+  public static func mean(_ a: [Float16]) -> Float16 {
+    guard !a.isEmpty else { return 0 }
+    return sum(a) / Float16(a.count)
+  }
+  
+  public static func sqrt(_ a: [Float16]) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = Float16(Foundation.sqrt(Float(a[i]))) }
+    return c
+  }
+  
+  public static func transpose(_ a: [Float16], rows: Int, columns: Int) -> [Float16] {
+    var c = [Float16](repeating: 0, count: rows * columns)
+    for r in 0..<rows {
+      for col in 0..<columns {
+        c[col * rows + r] = a[r * columns + col]
+      }
+    }
+    return c
+  }
+  
+  public static func clip(_ a: [Float16], to limit: Float16) -> [Float16] {
+    let count = a.count
+    var c = [Float16](repeating: 0, count: count)
+    for i in 0..<count { c[i] = Swift.max(-limit, Swift.min(limit, a[i])) }
+    return c
+  }
+  
+  public static func matmul(_ a: [Float16],
+                            _ b: [Float16],
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> [Float16] {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = [Float16](repeating: 0, count: aRows * bCols)
+    
+    for i in 0..<aRows {
+      for j in 0..<bCols {
+        var sum: Float16 = 0
+        for k in 0..<aCols {
+          sum += a[i * aCols + k] * b[k * bCols + j]
+        }
+        c[i * bCols + j] = sum
+      }
+    }
+    
+    return c
+  }
+  
+  // MARK: - Float16 Convolution / Padding
+  
+  public static func conv2d(signal: [Float16],
+                            filter: [Float16],
+                            strides: (Int, Int) = (1,1),
+                            padding: NumSwift.ConvPadding = .valid,
+                            filterSize: (rows: Int, columns: Int),
+                            inputSize: (rows: Int, columns: Int)) -> [Float16] {
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return result
+  }
+  
+  public static func transConv2d(signal: [Float16],
+                                 filter: [Float16],
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int)) -> [Float16] {
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return result
+  }
+  
+  public static func zeroPad(signal: [Float16],
+                             padding: NumSwiftPadding,
+                             inputSize: (rows: Int, columns: Int)) -> [Float16] {
+    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
+      return signal
+    }
+    // No flat C function for Float16 specific_zero_pad; do it in Swift
+    let expectedRows = inputSize.rows + padding.top + padding.bottom
+    let expectedColumns = inputSize.columns + padding.left + padding.right
+    var result = [Float16](repeating: 0, count: expectedRows * expectedColumns)
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
+      }
+    }
+    return result
+  }
+  
+  public static func zeroPad(signal: [Float16],
+                             filterSize: (rows: Int, columns: Int),
+                             inputSize: (rows: Int, columns: Int),
+                             stride: (Int, Int) = (1,1)) -> [Float16] {
+    let padding = NumSwiftC.paddingCalculation(strides: stride, padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let numPadding = NumSwiftPadding(top: padding.top, left: padding.left, right: padding.right, bottom: padding.bottom)
+    return zeroPad(signal: signal, padding: numPadding, inputSize: inputSize)
+  }
+  
+  public static func stridePad(signal: [Float16],
+                               strides: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int)) -> [Float16] {
+    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
+    
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    var result = [Float16](repeating: 0, count: newRows * newColumns)
+    
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  public static func flip180(_ a: [Float16], rows: Int, columns: Int) -> [Float16] {
+    var result = [Float16](repeating: 0, count: a.count)
+    for r in 0..<rows {
+      let srcRow = rows - 1 - r
+      let srcStart = srcRow * columns
+      let dstStart = r * columns
+      for c in 0..<columns {
+        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
+      }
+    }
+    return result
+  }
+  #endif
+}
+
+// MARK: ContiguousArray
+
+extension NumSwiftFlat {
+  
+  // MARK: - Element-wise Arithmetic (array + array)
+  
+  /// Element-wise addition using vDSP_vadd
+  /// we dont need count check here because if two arrays are different sizes we'll just add the number of elements in A
+  public static func add(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_vadd(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise subtraction (a - b) using vDSP_vsub
+  /// we dont need count check here because if two arrays are different sizes we'll just sub the number of elements in A
+  public static func subtract(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          // vDSP_vsub computes C = B - A (note reversed order)
+          vDSP_vsub(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise multiplication using vDSP_vmul
+  /// we dont need count check here because if two arrays are different sizes we'll just multiply the number of elements in A
+  public static func multiply(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_vmul(aBuf.baseAddress!, 1, bBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  /// Element-wise division (a / b) using vDSP_vdiv
+  /// we dont need count check here because if two arrays are different sizes we'll just divide the number of elements in A
+  public static func divide(_ a: ContiguousArray<Float>, _ b: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          // vDSP_vdiv computes C = B / A (note reversed order)
+          vDSP_vdiv(bBuf.baseAddress!, 1, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        }
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Scalar Arithmetic (array op scalar)
+  
+  /// Add scalar to every element using vDSP_vsadd
+  public static func add(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsadd(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Multiply every element by scalar using vDSP_vsmul
+  public static func multiply(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsmul(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Divide every element by scalar using vDSP_vsdiv
+  public static func divide(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vsdiv(aBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Subtract scalar from every element: result = a - scalar
+  public static func subtract(_ a: ContiguousArray<Float>, scalar: Float) -> ContiguousArray<Float> {
+    return add(a, scalar: -scalar)
+  }
+  
+  /// Scalar minus every element: result = scalar - a. Uses vDSP_vneg + vDSP_vsadd.
+  public static func subtract(scalar: Float, _ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    var s = scalar
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        // negate a
+        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+        // add scalar
+        vDSP_vsadd(cBuf.baseAddress!, 1, &s, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  /// Scalar divided by every element: result = scalar / a[i]
+  public static func divide(scalar: Float, _ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var s = scalar
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_svdiv(&s, aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Negation
+  
+  /// Negate every element using vDSP_vneg
+  public static func negate(_ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vneg(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Reductions
+  
+  /// Sum of all elements using vDSP_sve
+  public static func sum(_ a: ContiguousArray<Float>) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_sve(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  /// Sum of squares using vDSP_svesq
+  public static func sumOfSquares(_ a: ContiguousArray<Float>) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_svesq(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  /// Mean of all elements using vDSP_meanv
+  public static func mean(_ a: ContiguousArray<Float>) -> Float {
+    var result: Float = 0
+    a.withUnsafeBufferPointer { aBuf in
+      vDSP_meanv(aBuf.baseAddress!, 1, &result, vDSP_Length(a.count))
+    }
+    return result
+  }
+  
+  // MARK: - Square Root
+  
+  /// Element-wise square root using vForce
+  public static func sqrt(_ a: ContiguousArray<Float>) -> ContiguousArray<Float> {
+    let count = a.count
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        var n = Int32(count)
+        vvsqrtf(cBuf.baseAddress!, aBuf.baseAddress!, &n)
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Matrix Transpose
+  
+  /// Transpose a single 2D matrix stored as flat row-major using vDSP_mtrans
+  /// rows: is the number of rows in the input matrix
+  /// columns: is the number of columns in the input matrix
+  public static func transpose(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
+    var c = ContiguousArray<Float>(repeating: 0, count: rows * columns)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_mtrans(aBuf.baseAddress!, 1, cBuf.baseAddress!, 1, vDSP_Length(columns), vDSP_Length(rows))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Matrix Multiplication
+  
+  /// Performs matrix multiplication on flat ContiguousArray<Float> using Accelerate's vDSP_mmul.
+  public static func matmul(_ a: ContiguousArray<Float>,
+                            _ b: ContiguousArray<Float>,
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> ContiguousArray<Float> {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = ContiguousArray<Float>(repeating: 0, count: aRows * bCols)
+    
+    a.withUnsafeBufferPointer { aBuf in
+      b.withUnsafeBufferPointer { bBuf in
+        c.withUnsafeMutableBufferPointer { cBuf in
+          vDSP_mmul(aBuf.baseAddress!, 1,
+                    bBuf.baseAddress!, 1,
+                    cBuf.baseAddress!, 1,
+                    vDSP_Length(aRows),
+                    vDSP_Length(bCols),
+                    vDSP_Length(aCols))
+        }
+      }
+    }
+    
+    return c
+  }
+  
+  // MARK: - Clip
+  
+  /// Clip all values to [-limit, limit] using vDSP_vclip
+  public static func clip(_ a: ContiguousArray<Float>, to limit: Float) -> ContiguousArray<Float> {
+    let count = a.count
+    var low = -limit
+    var high = limit
+    var c = ContiguousArray<Float>(repeating: 0, count: count)
+    a.withUnsafeBufferPointer { aBuf in
+      c.withUnsafeMutableBufferPointer { cBuf in
+        vDSP_vclip(aBuf.baseAddress!, 1, &low, &high, cBuf.baseAddress!, 1, vDSP_Length(count))
+      }
+    }
+    return c
+  }
+  
+  // MARK: - Float16 Support
+  
+  // MARK: - Convolution (flat row-major)
+  
+  /// 2D convolution on flat row-major arrays via the C `nsc_conv1d` function.
+  public static func conv2d(signal: ContiguousArray<Float>,
+                            filter: ContiguousArray<Float>,
+                            strides: (Int, Int) = (1,1),
+                            padding: NumSwift.ConvPadding = .valid,
+                            filterSize: (rows: Int, columns: Int),
+                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  /// Transposed 2D convolution on flat row-major arrays via the C `nsc_transConv1d` function.
+  public static func transConv2d(signal: ContiguousArray<Float>,
+                                 filter: ContiguousArray<Float>,
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  /// Zero-pad a flat row-major 2D array with explicit padding values.
+  public static func zeroPad(signal: ContiguousArray<Float>,
+                             padding: NumSwiftPadding,
+                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
+      return signal
+    }
+    
+    let expectedRows = inputSize.rows + padding.top + padding.bottom
+    let expectedColumns = inputSize.columns + padding.left + padding.right
+    var result = ContiguousArray<Float>(repeating: 0, count: expectedRows * expectedColumns)
+    
+    // Copy original data into the padded result at the correct offsets
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  /// Zero-pad a flat row-major 2D array computed from filter/input sizes.
+  public static func zeroPad(signal: ContiguousArray<Float>,
+                             filterSize: (rows: Int, columns: Int),
+                             inputSize: (rows: Int, columns: Int),
+                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float> {
+    let result = NumSwiftC.zeroPad(signal: Array(signal),
+                                   filterSize: filterSize,
+                                   inputSize: inputSize,
+                                   stride: stride)
+    return ContiguousArray(result)
+  }
+  
+  /// Stride-pad a flat row-major 2D array (inserts zeros between elements).
+  /// Places original values at stride intervals in a larger zero-filled output.
+  public static func stridePad(signal: ContiguousArray<Float>,
+                               strides: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
+    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
+    
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    var result = ContiguousArray<Float>(repeating: 0, count: newRows * newColumns)
+    
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  /// Flip a flat row-major 2D matrix 180 degrees (reverse all elements, then reverse each row).
+  /// Equivalent to reversing the entire array then reversing each row segment.
+  public static func flip180(_ a: ContiguousArray<Float>, rows: Int, columns: Int) -> ContiguousArray<Float> {
+    var result = ContiguousArray<Float>(repeating: 0, count: a.count)
+    // flip180 = reverse rows, then reverse each row's columns
+    for r in 0..<rows {
+      let srcRow = rows - 1 - r
+      let srcStart = srcRow * columns
+      let dstStart = r * columns
+      for c in 0..<columns {
+        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
+      }
+    }
+    return result
+  }
+  
+  #if arch(arm64)
+  // Float16 versions use manual loops (no Accelerate support for Float16).
+  // The compiler can auto-vectorize these for ARM NEON.
+  
+  public static func add(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] + b[i] }
+    return c
+  }
+  
+  public static func subtract(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] - b[i] }
+    return c
+  }
+  
+  public static func multiply(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] * b[i] }
+    return c
+  }
+  
+  public static func divide(_ a: ContiguousArray<Float16>, _ b: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] / b[i] }
+    return c
+  }
+  
+  public static func add(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] + scalar }
+    return c
+  }
+  
+  public static func multiply(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] * scalar }
+    return c
+  }
+  
+  public static func divide(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = a[i] / scalar }
+    return c
+  }
+  
+  public static func subtract(_ a: ContiguousArray<Float16>, scalar: Float16) -> ContiguousArray<Float16> {
+    return add(a, scalar: -scalar)
+  }
+  
+  public static func subtract(scalar: Float16, _ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = scalar - a[i] }
+    return c
+  }
+  
+  public static func divide(scalar: Float16, _ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = scalar / a[i] }
+    return c
+  }
+  
+  public static func negate(_ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = -a[i] }
+    return c
+  }
+  
+  public static func sum(_ a: ContiguousArray<Float16>) -> Float16 {
+    var result: Float16 = 0
+    for i in 0..<a.count { result += a[i] }
+    return result
+  }
+  
+  public static func sumOfSquares(_ a: ContiguousArray<Float16>) -> Float16 {
+    var result: Float16 = 0
+    for i in 0..<a.count { result += a[i] * a[i] }
+    return result
+  }
+  
+  public static func mean(_ a: ContiguousArray<Float16>) -> Float16 {
+    guard !a.isEmpty else { return 0 }
+    return sum(a) / Float16(a.count)
+  }
+  
+  public static func sqrt(_ a: ContiguousArray<Float16>) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = Float16(Foundation.sqrt(Float(a[i]))) }
+    return c
+  }
+  
+  public static func transpose(_ a: ContiguousArray<Float16>, rows: Int, columns: Int) -> ContiguousArray<Float16> {
+    var c = ContiguousArray<Float16>(repeating: 0, count: rows * columns)
+    for r in 0..<rows {
+      for col in 0..<columns {
+        c[col * rows + r] = a[r * columns + col]
+      }
+    }
+    return c
+  }
+  
+  public static func clip(_ a: ContiguousArray<Float16>, to limit: Float16) -> ContiguousArray<Float16> {
+    let count = a.count
+    var c = ContiguousArray<Float16>(repeating: 0, count: count)
+    for i in 0..<count { c[i] = Swift.max(-limit, Swift.min(limit, a[i])) }
+    return c
+  }
+  
+  public static func matmul(_ a: ContiguousArray<Float16>,
+                            _ b: ContiguousArray<Float16>,
+                            aRows: Int,
+                            aCols: Int,
+                            bRows: Int,
+                            bCols: Int) -> ContiguousArray<Float16> {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    var c = ContiguousArray<Float16>(repeating: 0, count: aRows * bCols)
+    
+    for i in 0..<aRows {
+      for j in 0..<bCols {
+        var sum: Float16 = 0
+        for k in 0..<aCols {
+          sum += a[i * aCols + k] * b[k * bCols + j]
+        }
+        c[i * bCols + j] = sum
+      }
+    }
+    
+    return c
+  }
+  
+  // MARK: - Float16 Convolution / Padding
+  
+  public static func conv2d(signal: ContiguousArray<Float16>,
+                            filter: ContiguousArray<Float16>,
+                            strides: (Int, Int) = (1,1),
+                            padding: NumSwift.ConvPadding = .valid,
+                            filterSize: (rows: Int, columns: Int),
+                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  public static func transConv2d(signal: ContiguousArray<Float16>,
+                                 filter: ContiguousArray<Float16>,
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return ContiguousArray(result)
+  }
+  
+  public static func zeroPad(signal: ContiguousArray<Float16>,
+                             padding: NumSwiftPadding,
+                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
+      return signal
+    }
+    // No flat C function for Float16 specific_zero_pad; do it in Swift
+    let expectedRows = inputSize.rows + padding.top + padding.bottom
+    let expectedColumns = inputSize.columns + padding.left + padding.right
+    var result = ContiguousArray<Float16>(repeating: 0, count: expectedRows * expectedColumns)
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[(r + padding.top) * expectedColumns + (c + padding.left)] = signal[r * inputSize.columns + c]
+      }
+    }
+    return result
+  }
+  
+  public static func zeroPad(signal: ContiguousArray<Float16>,
+                             filterSize: (rows: Int, columns: Int),
+                             inputSize: (rows: Int, columns: Int),
+                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float16> {
+    let padding = NumSwiftC.paddingCalculation(strides: stride, padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let numPadding = NumSwiftPadding(top: padding.top, left: padding.left, right: padding.right, bottom: padding.bottom)
+    return zeroPad(signal: signal, padding: numPadding, inputSize: inputSize)
+  }
+  
+  public static func stridePad(signal: ContiguousArray<Float16>,
+                               strides: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
+    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else { return signal }
+    
+    let newRows = inputSize.rows + ((strides.rows - 1) * (inputSize.rows - 1))
+    let newColumns = inputSize.columns + ((strides.columns - 1) * (inputSize.columns - 1))
+    var result = ContiguousArray<Float16>(repeating: 0, count: newRows * newColumns)
+    
+    for r in 0..<inputSize.rows {
+      for c in 0..<inputSize.columns {
+        result[r * strides.rows * newColumns + c * strides.columns] = signal[r * inputSize.columns + c]
+      }
+    }
+    
+    return result
+  }
+  
+  public static func flip180(_ a: ContiguousArray<Float16>, rows: Int, columns: Int) -> ContiguousArray<Float16> {
+    var result = ContiguousArray<Float16>(repeating: 0, count: a.count)
+    for r in 0..<rows {
+      let srcRow = rows - 1 - r
+      let srcStart = srcRow * columns
+      let dstStart = r * columns
+      for c in 0..<columns {
+        result[dstStart + c] = a[srcStart + (columns - 1 - c)]
+      }
+    }
+    return result
+  }
+  #endif
+}

--- a/Sources/NumSwift/NumSwiftFlat.swift
+++ b/Sources/NumSwift/NumSwiftFlat.swift
@@ -236,16 +236,12 @@ public enum NumSwiftFlat  {
                             bRows: Int,
                             bCols: Int) -> [Float] {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = [Float](repeating: 0, count: aRows * bCols)
     
-    vDSP_mmul(a, 1,
-              b, 1,
-              &c, 1,
-              vDSP_Length(aRows),
-              vDSP_Length(bCols),
-              vDSP_Length(aCols))
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
+                                 aSize: (aRows, aCols),
+                                 bSize: (bRows, bCols))
     
-    return c
+    return out
   }
   
   // MARK: - Clip
@@ -512,19 +508,12 @@ public enum NumSwiftFlat  {
                             bRows: Int,
                             bCols: Int) -> [Float16] {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = [Float16](repeating: 0, count: aRows * bCols)
     
-    for i in 0..<aRows {
-      for j in 0..<bCols {
-        var sum: Float16 = 0
-        for k in 0..<aCols {
-          sum += a[i * aCols + k] * b[k * bCols + j]
-        }
-        c[i * bCols + j] = sum
-      }
-    }
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
+                                 aSize: (aRows, aCols),
+                                 bSize: (bRows, bCols))
     
-    return c
+    return out
   }
   
   // MARK: - Float16 Convolution / Padding
@@ -845,22 +834,12 @@ extension NumSwiftFlat {
                             bRows: Int,
                             bCols: Int) -> ContiguousArray<Float> {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = ContiguousArray<Float>(repeating: 0, count: aRows * bCols)
     
-    a.withUnsafeBufferPointer { aBuf in
-      b.withUnsafeBufferPointer { bBuf in
-        c.withUnsafeMutableBufferPointer { cBuf in
-          vDSP_mmul(aBuf.baseAddress!, 1,
-                    bBuf.baseAddress!, 1,
-                    cBuf.baseAddress!, 1,
-                    vDSP_Length(aRows),
-                    vDSP_Length(bCols),
-                    vDSP_Length(aCols))
-        }
-      }
-    }
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
+                                 aSize: (aRows, aCols),
+                                 bSize: (bRows, bCols))
     
-    return c
+    return ContiguousArray(out)
   }
   
   // MARK: - Clip
@@ -1111,19 +1090,12 @@ extension NumSwiftFlat {
                             bRows: Int,
                             bCols: Int) -> ContiguousArray<Float16> {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
-    var c = ContiguousArray<Float16>(repeating: 0, count: aRows * bCols)
     
-    for i in 0..<aRows {
-      for j in 0..<bCols {
-        var sum: Float16 = 0
-        for k in 0..<aCols {
-          sum += a[i * aCols + k] * b[k * bCols + j]
-        }
-        c[i * bCols + j] = sum
-      }
-    }
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
+                                 aSize: (aRows, aCols),
+                                 bSize: (bRows, bCols))
     
-    return c
+    return ContiguousArray(out)
   }
   
   // MARK: - Float16 Convolution / Padding

--- a/Sources/NumSwiftC/include/numswiftc.h
+++ b/Sources/NumSwiftC/include/numswiftc.h
@@ -52,6 +52,18 @@ extern void nsc_conv2d_f16(__fp16 *const *signal,
                        NSC_Size filter_size,
                        NSC_Size input_size);
 
+extern void nsc_matmul1d(NSC_Size a_size,
+                         NSC_Size b_size,
+                         const float a[],
+                         const float b[],
+                         float *result);
+
+extern void nsc_matmul1d_16(NSC_Size a_size,
+                            NSC_Size b_size,
+                            const __fp16 a[],
+                            const __fp16 b[],
+                            __fp16 *result);
+
 extern void nsc_matmul(NSC_Size a_size,
                        NSC_Size b_size,
                        float *const *a,

--- a/Sources/NumSwiftC/numswiftc.c
+++ b/Sources/NumSwiftC/numswiftc.c
@@ -11,6 +11,30 @@ static inline void winograd_matmul_blocked_f16(__fp16 *const *a, __fp16 *const *
                                               int rows, int cols_a, int cols_b);
 #endif
 
+extern void nsc_matmul1d_16(NSC_Size a_size,
+                            NSC_Size b_size,
+                            const __fp16 a[],
+                            const __fp16 b[],
+                            __fp16 *result) {
+  int rowFirst = a_size.rows;
+  int columnFirst = a_size.columns;
+  int columnSecond = b_size.columns;
+  
+  // Matrix multiplication for 1D arrays
+  // result[i,j] is at index (i * columnSecond + j)
+  // a[i,k] is at index (i * columnFirst + k)
+  // b[k,j] is at index (k * columnSecond + j)
+  for(int i = 0; i < rowFirst; ++i) {
+    for(int j = 0; j < columnSecond; ++j) {
+      __fp16 sum = 0.0f;
+      for(int k = 0; k < columnFirst; ++k) {
+        sum += a[i * columnFirst + k] * b[k * columnSecond + j];
+      }
+      result[i * columnSecond + j] = sum;
+    }
+  }
+}
+
 extern void nsc_matmul_16(NSC_Size a_size,
                           NSC_Size b_size,
                           __fp16 *const *a,
@@ -35,6 +59,30 @@ extern void nsc_matmul_16(NSC_Size a_size,
       for(int k = 0; k < columnFirst; ++k) {
         result[i][j] += a[i][k] * b[k][j];
       }
+    }
+  }
+}
+
+extern void nsc_matmul1d(NSC_Size a_size,
+                         NSC_Size b_size,
+                         const float a[],
+                         const float b[],
+                         float *result) {
+  int rowFirst = a_size.rows;
+  int columnFirst = a_size.columns;
+  int columnSecond = b_size.columns;
+  
+  // Matrix multiplication for 1D arrays
+  // result[i,j] is at index (i * columnSecond + j)
+  // a[i,k] is at index (i * columnFirst + k)
+  // b[k,j] is at index (k * columnSecond + j)
+  for(int i = 0; i < rowFirst; ++i) {
+    for(int j = 0; j < columnSecond; ++j) {
+      float sum = 0.0f;
+      for(int k = 0; k < columnFirst; ++k) {
+        sum += a[i * columnFirst + k] * b[k * columnSecond + j];
+      }
+      result[i * columnSecond + j] = sum;
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches numerics primitives and adds new C APIs; correctness and performance depend on dimension assumptions and the new 1D matmul implementation, so regressions would affect math outputs.
> 
> **Overview**
> Adds `NumSwiftFlat`, a new flat row-major API for `[Float]`/`ContiguousArray<Float>` providing vectorized elementwise math, reductions, transpose, clipping, and flat 2D conv/transpose-conv/padding helpers, with Float16 variants (loop-based on `arm64`).
> 
> Introduces 1D matrix multiplication support end-to-end: new C functions (`nsc_matmul1d`, `nsc_matmul1d_16`) and header exports, new Swift wrappers (`NumSwiftC.matmul1d` for Float/Float16), and uses these from `NumSwiftFlat.matmul`.
> 
> Extends `Array`/`ContiguousArray` utilities with a safe range subscript that pads with a default element, and adds several `ContiguousArray` safe/padded multi-index and dilated/padded range subscripts in `Float32.swift`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a28215b9eb1eb556eada1ba292fa1af6facea6e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->