### PR TITLE
Add pointer-accepting public APIs to NumSwiftFlat

### DIFF
--- a/Sources/NumSwift/NumSwiftFlatPointer.swift
+++ b/Sources/NumSwift/NumSwiftFlatPointer.swift
@@ -1,0 +1,425 @@
+//
+//  NumSwiftFlatPointer.swift
+//  NumSwift
+//
+//  Created by William Vabrinskas on 3/4/26.
+//
+
+import Accelerate
+import Foundation
+import NumSwiftC
+
+// MARK: - Pointer-Based Flat Array Operations
+
+/// Provides pointer-accepting overloads of `NumSwiftFlat` operations.
+/// These accept `UnsafePointer` / `UnsafeMutablePointer` directly,
+/// avoiding intermediate `Array` or `ContiguousArray` allocations.
+/// Callers are responsible for ensuring pointer validity and correct `count`.
+public extension NumSwiftFlat {
+
+  // MARK: - Element-wise Arithmetic (Float, pointer-to-pointer)
+
+  /// `result[i] = a[i] + b[i]`
+  static func add(_ a: UnsafePointer<Float>,
+                  _ b: UnsafePointer<Float>,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    vDSP_vadd(a, 1, b, 1, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = a[i] - b[i]`
+  static func sub(_ a: UnsafePointer<Float>,
+                  _ b: UnsafePointer<Float>,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    // vDSP_vsub computes C = B - A, so pass (b, a) to get a - b
+    vDSP_vsub(b, 1, a, 1, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = a[i] * b[i]`
+  static func mul(_ a: UnsafePointer<Float>,
+                  _ b: UnsafePointer<Float>,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    vDSP_vmul(a, 1, b, 1, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = a[i] / b[i]`
+  static func div(_ a: UnsafePointer<Float>,
+                  _ b: UnsafePointer<Float>,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    // vDSP_vdiv computes C = B / A, so pass (b, a) to get a / b
+    vDSP_vdiv(b, 1, a, 1, result, 1, vDSP_Length(count))
+  }
+
+  // MARK: - Scalar Arithmetic (Float)
+
+  /// `result[i] = a[i] + scalar`
+  static func add(_ a: UnsafePointer<Float>,
+                  scalar: Float,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    var s = scalar
+    vDSP_vsadd(a, 1, &s, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = a[i] - scalar`
+  static func sub(_ a: UnsafePointer<Float>,
+                  scalar: Float,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    nsc_sub_scalar(a, scalar, Int32(count), result)
+  }
+
+  /// `result[i] = scalar - a[i]`
+  static func sub(scalar: Float,
+                  _ a: UnsafePointer<Float>,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    var s = scalar
+    vDSP_vneg(a, 1, result, 1, vDSP_Length(count))
+    vDSP_vsadd(result, 1, &s, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = a[i] * scalar`
+  static func mul(_ a: UnsafePointer<Float>,
+                  scalar: Float,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    var s = scalar
+    vDSP_vsmul(a, 1, &s, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = a[i] / scalar`
+  static func div(_ a: UnsafePointer<Float>,
+                  scalar: Float,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    var s = scalar
+    vDSP_vsdiv(a, 1, &s, result, 1, vDSP_Length(count))
+  }
+
+  /// `result[i] = scalar / a[i]`
+  static func div(scalar: Float,
+                  _ a: UnsafePointer<Float>,
+                  result: UnsafeMutablePointer<Float>,
+                  count: Int) {
+    var s = scalar
+    vDSP_svdiv(&s, a, 1, result, 1, vDSP_Length(count))
+  }
+
+  // MARK: - Reductions (Float)
+
+  /// Returns the sum of all elements.
+  static func sum(_ a: UnsafePointer<Float>, count: Int) -> Float {
+    var result: Float = 0
+    vDSP_sve(a, 1, &result, vDSP_Length(count))
+    return result
+  }
+
+  /// Returns the mean of all elements.
+  static func mean(_ a: UnsafePointer<Float>, count: Int) -> Float {
+    var result: Float = 0
+    vDSP_meanv(a, 1, &result, vDSP_Length(count))
+    return result
+  }
+
+  /// Returns the sum of squares of all elements.
+  static func sumOfSquares(_ a: UnsafePointer<Float>, count: Int) -> Float {
+    var result: Float = 0
+    vDSP_svesq(a, 1, &result, vDSP_Length(count))
+    return result
+  }
+
+  // MARK: - Negation (Float)
+
+  /// `result[i] = -a[i]`
+  static func negate(_ a: UnsafePointer<Float>,
+                     result: UnsafeMutablePointer<Float>,
+                     count: Int) {
+    vDSP_vneg(a, 1, result, 1, vDSP_Length(count))
+  }
+
+  // MARK: - Square Root (Float)
+
+  /// `result[i] = sqrt(a[i])`
+  static func sqrt(_ a: UnsafePointer<Float>,
+                   result: UnsafeMutablePointer<Float>,
+                   count: Int) {
+    var n = Int32(count)
+    vvsqrtf(result, a, &n)
+  }
+
+  // MARK: - Clip (Float)
+
+  /// Clamp every element to `[-limit, limit]`.
+  static func clip(_ a: UnsafePointer<Float>,
+                   result: UnsafeMutablePointer<Float>,
+                   count: Int,
+                   limit: Float) {
+    var low = -limit
+    var high = limit
+    vDSP_vclip(a, 1, &low, &high, result, 1, vDSP_Length(count))
+  }
+
+  // MARK: - Matrix Transpose (Float)
+
+  /// Transpose a row-major matrix in-place (a -> result with swapped dimensions).
+  static func transpose(_ a: UnsafePointer<Float>,
+                        result: UnsafeMutablePointer<Float>,
+                        rows: Int,
+                        columns: Int) {
+    vDSP_mtrans(a, 1, result, 1, vDSP_Length(columns), vDSP_Length(rows))
+  }
+
+  // MARK: - Matrix Multiplication (Float)
+
+  /// `result = a[aRows x aCols] * b[bRows x bCols]`  (row-major)
+  static func matmul(_ a: UnsafePointer<Float>,
+                     _ b: UnsafePointer<Float>,
+                     result: UnsafeMutablePointer<Float>,
+                     aRows: Int,
+                     aCols: Int,
+                     bRows: Int,
+                     bCols: Int) {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    nsc_matmul1d(.init(rows: Int32(aRows), columns: Int32(aCols), depth: 1),
+                 .init(rows: Int32(bRows), columns: Int32(bCols), depth: 1),
+                 a, b, result)
+  }
+
+  // MARK: - Convolution (Float)
+
+  /// 2D convolution on flat row-major data, writing into caller-provided result buffer.
+  static func conv2d(signal: UnsafePointer<Float>,
+                     filter: UnsafePointer<Float>,
+                     result: UnsafeMutablePointer<Float>,
+                     strides: (Int, Int) = (1, 1),
+                     padding: NumSwift.ConvPadding = .valid,
+                     filterSize: (rows: Int, columns: Int),
+                     inputSize: (rows: Int, columns: Int)) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_conv1d(signal, filter, result,
+               .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+               nscPadding,
+               .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+               .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1))
+  }
+
+  /// Transposed 2D convolution on flat row-major data, writing into caller-provided result buffer.
+  static func transConv2d(signal: UnsafePointer<Float>,
+                          filter: UnsafePointer<Float>,
+                          result: UnsafeMutablePointer<Float>,
+                          strides: (Int, Int) = (1, 1),
+                          padding: NumSwift.ConvPadding = .valid,
+                          filterSize: (rows: Int, columns: Int),
+                          inputSize: (rows: Int, columns: Int)) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_transConv1d(signal, filter, result,
+                    .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                    nscPadding,
+                    .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                    .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1))
+  }
+}
+
+// MARK: - Float16 Pointer APIs
+
+#if arch(arm64)
+public extension NumSwiftFlat {
+
+  // MARK: - Element-wise Arithmetic (Float16, pointer-to-pointer)
+
+  /// `result[i] = a[i] + b[i]`
+  static func add(_ a: UnsafePointer<Float16>,
+                  _ b: UnsafePointer<Float16>,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_add(a, b, Int32(count), result)
+  }
+
+  /// `result[i] = a[i] - b[i]`
+  static func sub(_ a: UnsafePointer<Float16>,
+                  _ b: UnsafePointer<Float16>,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_sub(a, b, Int32(count), result)
+  }
+
+  /// `result[i] = a[i] * b[i]`
+  static func mul(_ a: UnsafePointer<Float16>,
+                  _ b: UnsafePointer<Float16>,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_mult(a, b, Int32(count), result)
+  }
+
+  /// `result[i] = a[i] / b[i]`
+  static func div(_ a: UnsafePointer<Float16>,
+                  _ b: UnsafePointer<Float16>,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_div(a, b, Int32(count), result)
+  }
+
+  // MARK: - Scalar Arithmetic (Float16)
+
+  /// `result[i] = a[i] + scalar`
+  static func add(_ a: UnsafePointer<Float16>,
+                  scalar: Float16,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_add_scalar(scalar, a, Int32(count), result)
+  }
+
+  /// `result[i] = a[i] - scalar`
+  static func sub(_ a: UnsafePointer<Float16>,
+                  scalar: Float16,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_sub_scalar_f16(a, scalar, Int32(count), result)
+  }
+
+  /// `result[i] = scalar - a[i]`
+  static func sub(scalar: Float16,
+                  _ a: UnsafePointer<Float16>,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_sub_scalar_array_f16(scalar, a, Int32(count), result)
+  }
+
+  /// `result[i] = a[i] * scalar`
+  static func mul(_ a: UnsafePointer<Float16>,
+                  scalar: Float16,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_mult_scalar(scalar, a, Int32(count), result)
+  }
+
+  /// `result[i] = a[i] / scalar`
+  static func div(_ a: UnsafePointer<Float16>,
+                  scalar: Float16,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_div_array_scalar(a, scalar, Int32(count), result)
+  }
+
+  /// `result[i] = scalar / a[i]`
+  static func div(scalar: Float16,
+                  _ a: UnsafePointer<Float16>,
+                  result: UnsafeMutablePointer<Float16>,
+                  count: Int) {
+    nsc_div_scalar_array(scalar, a, Int32(count), result)
+  }
+
+  // MARK: - Reductions (Float16)
+
+  /// Returns the sum of all elements.
+  static func sum(_ a: UnsafePointer<Float16>, count: Int) -> Float16 {
+    nsc_sum(a, Int32(count))
+  }
+
+  /// Returns the mean of all elements.
+  static func mean(_ a: UnsafePointer<Float16>, count: Int) -> Float16 {
+    nsc_mean(a, Int32(count))
+  }
+
+  /// Returns the sum of squares of all elements.
+  static func sumOfSquares(_ a: UnsafePointer<Float16>, count: Int) -> Float16 {
+    nsc_sum_of_squares(a, Int32(count))
+  }
+
+  // MARK: - Negation (Float16)
+
+  /// `result[i] = -a[i]`
+  static func negate(_ a: UnsafePointer<Float16>,
+                     result: UnsafeMutablePointer<Float16>,
+                     count: Int) {
+    for i in 0..<count { result[i] = -a[i] }
+  }
+
+  // MARK: - Square Root (Float16)
+
+  /// `result[i] = sqrt(a[i])`
+  static func sqrt(_ a: UnsafePointer<Float16>,
+                   result: UnsafeMutablePointer<Float16>,
+                   count: Int) {
+    for i in 0..<count { result[i] = Float16(Foundation.sqrt(Float(a[i]))) }
+  }
+
+  // MARK: - Clip (Float16)
+
+  /// Clamp every element to `[-limit, limit]`.
+  static func clip(_ a: UnsafePointer<Float16>,
+                   result: UnsafeMutablePointer<Float16>,
+                   count: Int,
+                   limit: Float16) {
+    for i in 0..<count { result[i] = Swift.max(-limit, Swift.min(limit, a[i])) }
+  }
+
+  // MARK: - Matrix Transpose (Float16)
+
+  /// Transpose a row-major matrix (a -> result with swapped dimensions).
+  static func transpose(_ a: UnsafePointer<Float16>,
+                        result: UnsafeMutablePointer<Float16>,
+                        rows: Int,
+                        columns: Int) {
+    for r in 0..<rows {
+      for c in 0..<columns {
+        result[c * rows + r] = a[r * columns + c]
+      }
+    }
+  }
+
+  // MARK: - Matrix Multiplication (Float16)
+
+  /// `result = a[aRows x aCols] * b[bRows x bCols]`  (row-major)
+  static func matmul(_ a: UnsafePointer<Float16>,
+                     _ b: UnsafePointer<Float16>,
+                     result: UnsafeMutablePointer<Float16>,
+                     aRows: Int,
+                     aCols: Int,
+                     bRows: Int,
+                     bCols: Int) {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    nsc_matmul1d_16(.init(rows: Int32(aRows), columns: Int32(aCols), depth: 1),
+                    .init(rows: Int32(bRows), columns: Int32(bCols), depth: 1),
+                    a, b, result)
+  }
+
+  // MARK: - Convolution (Float16)
+
+  /// 2D convolution on flat row-major data, writing into caller-provided result buffer.
+  static func conv2d(signal: UnsafePointer<Float16>,
+                     filter: UnsafePointer<Float16>,
+                     result: UnsafeMutablePointer<Float16>,
+                     strides: (Int, Int) = (1, 1),
+                     padding: NumSwift.ConvPadding = .valid,
+                     filterSize: (rows: Int, columns: Int),
+                     inputSize: (rows: Int, columns: Int)) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_conv1d_f16(signal, filter, result,
+                   .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                   nscPadding,
+                   .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                   .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1))
+  }
+
+  /// Transposed 2D convolution on flat row-major data, writing into caller-provided result buffer.
+  static func transConv2d(signal: UnsafePointer<Float16>,
+                          filter: UnsafePointer<Float16>,
+                          result: UnsafeMutablePointer<Float16>,
+                          strides: (Int, Int) = (1, 1),
+                          padding: NumSwift.ConvPadding = .valid,
+                          filterSize: (rows: Int, columns: Int),
+                          inputSize: (rows: Int, columns: Int)) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_transConv1d_f16(signal, filter, result,
+                        .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                        nscPadding,
+                        .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                        .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1))
+  }
+}
+#endif

--- a/Tests/NumSwiftTests/NumSwiftFlatPointerTests.swift
+++ b/Tests/NumSwiftTests/NumSwiftFlatPointerTests.swift
@@ -1,0 +1,405 @@
+import XCTest
+@testable import NumSwift
+
+final class NumSwiftFlatPointerTests: XCTestCase {
+
+  // MARK: - Float Element-wise Arithmetic
+
+  func testAddFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let b: [Float] = [10, 20, 30, 40, 50]
+    let expected = ContiguousArray<Float>(a) + ContiguousArray<Float>(b)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.add(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testSubFloat() {
+    let a: [Float] = [10, 20, 30, 40, 50]
+    let b: [Float] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float>(a) - ContiguousArray<Float>(b)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.sub(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testMulFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let b: [Float] = [2, 3, 4, 5, 6]
+    let expected = ContiguousArray<Float>(a) * ContiguousArray<Float>(b)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.mul(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testDivFloat() {
+    let a: [Float] = [10, 20, 30, 40, 50]
+    let b: [Float] = [2, 4, 5, 8, 10]
+    let expected = ContiguousArray<Float>(a) / ContiguousArray<Float>(b)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.div(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  // MARK: - Float Scalar Arithmetic
+
+  func testAddScalarFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let scalar: Float = 10
+    let expected = ContiguousArray<Float>(a) + scalar
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.add(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testSubScalarFloat() {
+    let a: [Float] = [10, 20, 30, 40, 50]
+    let scalar: Float = 5
+    let expected = ContiguousArray<Float>(a) - scalar
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.sub(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testSubScalarFromArrayFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let scalar: Float = 10
+    let expected = scalar - ContiguousArray<Float>(a)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.sub(scalar: scalar, aPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testMulScalarFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let scalar: Float = 3
+    let expected = ContiguousArray<Float>(a) * scalar
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.mul(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testDivScalarFloat() {
+    let a: [Float] = [10, 20, 30, 40, 50]
+    let scalar: Float = 5
+    let expected = ContiguousArray<Float>(a) / scalar
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.div(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testDivScalarByArrayFloat() {
+    let a: [Float] = [2, 4, 5, 8, 10]
+    let scalar: Float = 100
+    let expected = scalar / ContiguousArray<Float>(a)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.div(scalar: scalar, aPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  // MARK: - Float Reductions
+
+  func testSumFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float>(a).sum
+
+    let result = a.withUnsafeBufferPointer { aPtr in
+      NumSwiftFlat.sum(aPtr.baseAddress!, count: a.count)
+    }
+    XCTAssertEqual(result, expected, accuracy: 1e-6)
+  }
+
+  func testMeanFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float>(a).mean
+
+    let result = a.withUnsafeBufferPointer { aPtr in
+      NumSwiftFlat.mean(aPtr.baseAddress!, count: a.count)
+    }
+    XCTAssertEqual(result, expected, accuracy: 1e-6)
+  }
+
+  func testSumOfSquaresFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float>(a).sumOfSquares
+
+    let result = a.withUnsafeBufferPointer { aPtr in
+      NumSwiftFlat.sumOfSquares(aPtr.baseAddress!, count: a.count)
+    }
+    XCTAssertEqual(result, expected, accuracy: 1e-6)
+  }
+
+  // MARK: - Float Unary Operations
+
+  func testNegateFloat() {
+    let a: [Float] = [1, -2, 3, -4, 5]
+    let expected = NumSwiftFlat.negate(a)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.negate(aPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testSqrtFloat() {
+    let a: [Float] = [1, 4, 9, 16, 25]
+    let expected = NumSwiftFlat.sqrt(a)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.sqrt(aPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testClipFloat() {
+    let a: [Float] = [-5, -1, 0, 1, 5]
+    let expected = NumSwiftFlat.clip(a, to: 2)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.clip(aPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count, limit: 2)
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  // MARK: - Float Matrix Operations
+
+  func testTransposeFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5, 6]
+    let expected = NumSwiftFlat.transpose(a, rows: 2, columns: 3)
+
+    var result = [Float](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.transpose(aPtr.baseAddress!, result: rPtr.baseAddress!, rows: 2, columns: 3)
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testMatmulFloat() {
+    let a: [Float] = [1, 2, 3, 4, 5, 6]
+    let b: [Float] = [7, 8, 9, 10, 11, 12]
+    let expected = NumSwiftFlat.matmul(a, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+
+    var result = [Float](repeating: 0, count: 4)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.matmul(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!,
+                              aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+        }
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  // MARK: - Float16 Tests
+
+  #if arch(arm64)
+  func testAddFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5]
+    let b: [Float16] = [10, 20, 30, 40, 50]
+    let expected = ContiguousArray<Float16>(a) + ContiguousArray<Float16>(b)
+
+    var result = [Float16](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.add(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testSubFloat16() {
+    let a: [Float16] = [10, 20, 30, 40, 50]
+    let b: [Float16] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float16>(a) - ContiguousArray<Float16>(b)
+
+    var result = [Float16](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.sub(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testMulFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5]
+    let b: [Float16] = [2, 3, 4, 5, 6]
+    let expected = ContiguousArray<Float16>(a) * ContiguousArray<Float16>(b)
+
+    var result = [Float16](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.mul(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testDivFloat16() {
+    let a: [Float16] = [10, 20, 30, 40, 50]
+    let b: [Float16] = [2, 4, 5, 8, 10]
+    let expected = ContiguousArray<Float16>(a) / ContiguousArray<Float16>(b)
+
+    var result = [Float16](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.div(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!, count: a.count)
+        }
+      }
+    }
+    XCTAssertEqual(result, Array(expected))
+  }
+
+  func testSumFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float16>(a).sum
+
+    let result = a.withUnsafeBufferPointer { aPtr in
+      NumSwiftFlat.sum(aPtr.baseAddress!, count: a.count)
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testMeanFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5]
+    let expected = ContiguousArray<Float16>(a).mean
+
+    let result = a.withUnsafeBufferPointer { aPtr in
+      NumSwiftFlat.mean(aPtr.baseAddress!, count: a.count)
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testMatmulFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5, 6]
+    let b: [Float16] = [7, 8, 9, 10, 11, 12]
+    let expected = NumSwiftFlat.matmul(a, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+
+    var result = [Float16](repeating: 0, count: 4)
+    a.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.matmul(aPtr.baseAddress!, bPtr.baseAddress!, result: rPtr.baseAddress!,
+                              aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+        }
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testTransposeFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5, 6]
+    let expected = NumSwiftFlat.transpose(a, rows: 2, columns: 3)
+
+    var result = [Float16](repeating: 0, count: a.count)
+    a.withUnsafeBufferPointer { aPtr in
+      result.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.transpose(aPtr.baseAddress!, result: rPtr.baseAddress!, rows: 2, columns: 3)
+      }
+    }
+    XCTAssertEqual(result, expected)
+  }
+
+  func testScalarArithmeticFloat16() {
+    let a: [Float16] = [1, 2, 3, 4, 5]
+    let scalar: Float16 = 10
+
+    var addResult = [Float16](repeating: 0, count: a.count)
+    var mulResult = [Float16](repeating: 0, count: a.count)
+    var divResult = [Float16](repeating: 0, count: a.count)
+
+    a.withUnsafeBufferPointer { aPtr in
+      addResult.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.add(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+      mulResult.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.mul(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+      divResult.withUnsafeMutableBufferPointer { rPtr in
+        NumSwiftFlat.div(aPtr.baseAddress!, scalar: scalar, result: rPtr.baseAddress!, count: a.count)
+      }
+    }
+
+    XCTAssertEqual(addResult, Array(ContiguousArray<Float16>(a) + scalar))
+    XCTAssertEqual(mulResult, Array(ContiguousArray<Float16>(a) * scalar))
+    XCTAssertEqual(divResult, Array(ContiguousArray<Float16>(a) / scalar))
+  }
+  #endif
+}


### PR DESCRIPTION
## Summary

- Adds `UnsafePointer`/`UnsafeMutablePointer` overloads to `NumSwiftFlat` for all key operations: element-wise arithmetic, scalar arithmetic, reductions, negate, sqrt, clip, transpose, matmul, conv2d, and transConv2d
- Both `Float` and `Float16` variants included (Float16 under `#if arch(arm64)`)
- These are thin wrappers over the same `vDSP` and `nsc_*` C functions the existing `Array`/`ContiguousArray` APIs use, just without the `withUnsafeBufferPointer` overhead on the caller side
- Enables callers with raw pointer-backed storage (e.g. `MTLBuffer.contents()`) to call NumSwift math directly without intermediate array allocations

This is a prerequisite for the Neuron framework's Tensor storage migration to `MTLBuffer`-backed memory for zero-copy GPU access on Apple Silicon.

## Test plan

- [x] 27 new tests in `NumSwiftFlatPointerTests` validating pointer API results match existing Array-based API results
- [x] All 100 tests pass (73 existing + 27 new)
- [x] Build succeeds with no new warnings


Made with [Cursor](https://cursor.com)