### PR TITLE
revert uninitialized array commit

### DIFF
--- a/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
@@ -43,29 +43,6 @@ public struct NoiseC {
 }
 
 public struct NumSwiftC {
-  @inline(__always)
-  static func uninitializedArray<Element>(
-    count: Int,
-    _ fill: (UnsafeMutableBufferPointer<Element>) -> Void
-  ) -> [Element] {
-    guard count > 0 else { return [] }
-    return Array<Element>(unsafeUninitializedCapacity: count) { buffer, initializedCount in
-      fill(buffer)
-      initializedCount = count
-    }
-  }
-  
-  @inline(__always)
-  static func uninitializedContiguousArray<Element>(
-    count: Int,
-    _ fill: (UnsafeMutableBufferPointer<Element>) -> Void
-  ) -> ContiguousArray<Element> {
-    guard count > 0 else { return [] }
-    return ContiguousArray<Element>(unsafeUninitializedCapacity: count) { buffer, initializedCount in
-      fill(buffer)
-      initializedCount = count
-    }
-  }
   
   public static func add(_ a: [[Float]], _ b: [[Float]]) -> [[Float]] {
     let shape = a.shape
@@ -392,36 +369,16 @@ public struct NumSwiftC {
                             b: [Float],
                             aSize: (rows: Int, columns: Int),
                             bSize: (rows: Int, columns: Int)) -> [Float] {
-    let count = aSize.rows * bSize.columns
-    return uninitializedArray(count: count) { resultBuffer in
-      a.withUnsafeBufferPointer { aBuffer in
-        b.withUnsafeBufferPointer { bBuffer in
-          nsc_matmul1d(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
-                       .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
-                       aBuffer.baseAddress,
-                       bBuffer.baseAddress,
-                       resultBuffer.baseAddress)
-        }
-      }
-    }
-  }
-  
-  public static func matmul1d(_ a: ContiguousArray<Float>,
-                              b: ContiguousArray<Float>,
-                              aSize: (rows: Int, columns: Int),
-                              bSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    let count = aSize.rows * bSize.columns
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      a.withUnsafeBufferPointer { aBuffer in
-        b.withUnsafeBufferPointer { bBuffer in
-          nsc_matmul1d(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
-                       .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
-                       aBuffer.baseAddress,
-                       bBuffer.baseAddress,
-                       resultBuffer.baseAddress)
-        }
-      }
-    }
+    
+    var results: [Float] = [Float](repeating: 0, count: aSize.rows * bSize.columns)
+    
+    nsc_matmul1d(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                 .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                 a,
+                 b,
+                 &results)
+    
+    return results
   }
   
   public static func matmul(_ a: [[Float]],
@@ -547,45 +504,24 @@ public struct NumSwiftC {
       return signal
     }
     
+    let shape = signal.shape
     let rows = signalSize.rows
     let columns = signalSize.columns
     
     let newRows = rows + ((strides.rows - 1) * (rows - 1))
     let newColumns = columns + ((strides.columns - 1) * (columns - 1))
     
-    let count = newRows * newColumns
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_stride_pad(signalBuffer.baseAddress,
-                       resultBuffer.baseAddress,
-                       NSC_Size(rows: Int32(rows), columns: Int32(columns)),
-                       NSC_Size(rows: Int32(strides.rows), columns: Int32(strides.columns)))
-      }
-    }
-  }
-  
-  public static func stridePad1D(signal: ContiguousArray<Float>,
-                                 strides: (rows: Int, columns: Int),
-                                 signalSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else {
-      return signal
-    }
+    var results: [Float] = [Float](repeating: 0, count: newRows * newColumns)
     
-    let rows = signalSize.rows
-    let columns = signalSize.columns
+    let flatSignal: [Float] = signal
     
-    let newRows = rows + ((strides.rows - 1) * (rows - 1))
-    let newColumns = columns + ((strides.columns - 1) * (columns - 1))
-    let count = newRows * newColumns
+    nsc_stride_pad(flatSignal,
+                   &results, NSC_Size(rows: Int32(rows),
+                                      columns: Int32(columns)),
+                   NSC_Size(rows: Int32(strides.rows),
+                            columns: Int32(strides.columns)))
     
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_stride_pad(signalBuffer.baseAddress,
-                       resultBuffer.baseAddress,
-                       NSC_Size(rows: Int32(rows), columns: Int32(columns)),
-                       NSC_Size(rows: Int32(strides.rows), columns: Int32(strides.columns)))
-      }
-    }
+    return results
   }
   
   public static func zeroPad(signal: [[Float]],
@@ -711,47 +647,17 @@ public struct NumSwiftC {
     let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
     
     let paddingInt: UInt32 = padding == .valid ? 0 : 1
-    let count = expectedRows * expectedColumns
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_conv1d(signalBuffer.baseAddress,
-                     filterBuffer.baseAddress,
-                     resultBuffer.baseAddress,
-                     NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                     NSC_Padding(rawValue: paddingInt),
-                     NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                     NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
-  }
-  
-  public static func conv1d(signal: ContiguousArray<Float>,
-                            filter: ContiguousArray<Float>,
-                            strides: (Int, Int) = (1,1),
-                            padding: NumSwift.ConvPadding = .valid,
-                            filterSize: (rows: Int, columns: Int),
-                            inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    let paddingResult = padding.extra(inputSize: inputSize, filterSize: filterSize, stride: strides)
-    let expectedRows = ((inputSize.rows - filterSize.rows + paddingResult.top + paddingResult.bottom) / strides.0) + 1
-    let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
+    var results: [Float] = [Float](repeating: 0, count: expectedRows * expectedColumns)
     
-    let paddingInt: UInt32 = padding == .valid ? 0 : 1
-    let count = expectedRows * expectedColumns
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_conv1d(signalBuffer.baseAddress,
-                     filterBuffer.baseAddress,
-                     resultBuffer.baseAddress,
-                     NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                     NSC_Padding(rawValue: paddingInt),
-                     NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                     NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
+    nsc_conv1d(signal,
+               filter,
+               &results,
+               NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+               NSC_Padding(rawValue: paddingInt),
+               NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+               NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+    
+    return results
   }
   
   public static func transConv2d(signal: [[Float]],
@@ -832,61 +738,17 @@ public struct NumSwiftC {
     
     let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
     let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
-    let count = (rows - (padTop + padBottom)) * (columns - (padLeft + padRight))
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_transConv1d(signalBuffer.baseAddress,
-                          filterBuffer.baseAddress,
-                          resultBuffer.baseAddress,
-                          NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                          NSC_Padding(rawValue: paddingInt),
-                          NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                          NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
-  }
-  
-  public static func transConv1d(signal: ContiguousArray<Float>,
-                                 filter: ContiguousArray<Float>,
-                                 strides: (Int, Int) = (1,1),
-                                 padding: NumSwift.ConvPadding = .valid,
-                                 filterSize: (rows: Int, columns: Int),
-                                 inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    let paddingInt: UInt32 = padding == .valid ? 0 : 1
-    var padLeft = 0
-    var padRight = 0
-    var padTop = 0
-    var padBottom = 0
+    var results: [Float] = [Float](repeating: 0,
+                                   count: (rows - (padTop + padBottom)) * (columns - (padLeft + padRight)))
     
-    switch padding {
-    case .same:
-      padLeft = Int(floor(Double(filterSize.rows - strides.0) / Double(2)))
-      padRight = filterSize.rows - strides.0 - padLeft
-      padTop = Int(floor(Double(filterSize.columns - strides.1) / Double(2)))
-      padBottom = filterSize.columns - strides.1 - padTop
-      
-    case .valid:
-      break
-    }
-    
-    let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
-    let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
-    let count = (rows - (padTop + padBottom)) * (columns - (padLeft + padRight))
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_transConv1d(signalBuffer.baseAddress,
-                          filterBuffer.baseAddress,
-                          resultBuffer.baseAddress,
-                          NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                          NSC_Padding(rawValue: paddingInt),
-                          NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                          NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
+    nsc_transConv1d(signal,
+                    filter,
+                    &results,
+                    NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                    NSC_Padding(rawValue: paddingInt),
+                    NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                    NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+    return results
   }
   
   public static func paddingCalculation(strides: (Int, Int) = (1,1),
@@ -928,36 +790,19 @@ public struct NumSwiftC {
     
     let count = (inputSize.rows + padding.top + padding.bottom) * (inputSize.columns + padding.left + padding.right)
     
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_zero_pad(signalBuffer.baseAddress,
-                     resultBuffer.baseAddress,
-                     NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                     NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
-                     NSC_Size(rows: Int32(stride.0), columns: Int32(stride.1)))
-      }
-    }
-  }
-  
-  public static func zeroPad(signal: ContiguousArray<Float>,
-                             filterSize: (rows: Int, columns: Int),
-                             inputSize: (rows: Int, columns: Int),
-                             stride: (Int, Int) = (1,1)) -> ContiguousArray<Float> {
-    let padding = NumSwiftC.paddingCalculation(strides: stride,
-                                               padding: .same,
-                                               filterSize: filterSize,
-                                               inputSize: inputSize)
-    let count = (inputSize.rows + padding.top + padding.bottom) * (inputSize.columns + padding.left + padding.right)
+    var results: [Float] = [Float](repeating: 0,
+                                   count: count)
     
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_zero_pad(signalBuffer.baseAddress,
-                     resultBuffer.baseAddress,
-                     NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                     NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
-                     NSC_Size(rows: Int32(stride.0), columns: Int32(stride.1)))
-      }
-    }
+    nsc_zero_pad(signal,
+                 &results,
+                 NSC_Size(rows: Int32(filterSize.rows),
+                          columns: Int32(filterSize.columns)),
+                 NSC_Size(rows: Int32(inputSize.rows),
+                          columns: Int32(inputSize.columns)),
+                 NSC_Size(rows: Int32(stride.0),
+                          columns: Int32(stride.1)))
+    
+    return results
   }
 
   public static func zeroPad1D(signal: [Float],
@@ -969,41 +814,17 @@ public struct NumSwiftC {
 
     let expectedRows = inputSize.rows + padding.top + padding.bottom
     let expectedColumns = inputSize.columns + padding.left + padding.right
-    let count = expectedRows * expectedColumns
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_specific_zero_pad_1d(signalBuffer.baseAddress,
-                                 resultBuffer.baseAddress,
-                                 NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
-                                 Int32(padding.top),
-                                 Int32(padding.bottom),
-                                 Int32(padding.left),
-                                 Int32(padding.right))
-      }
-    }
-  }
-  
-  public static func zeroPad1D(signal: ContiguousArray<Float>,
-                               padding: NumSwiftPadding,
-                               inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    guard padding.right > 0 || padding.left > 0 || padding.top > 0 || padding.bottom > 0 else {
-      return signal
-    }
-    
-    let expectedRows = inputSize.rows + padding.top + padding.bottom
-    let expectedColumns = inputSize.columns + padding.left + padding.right
-    let count = expectedRows * expectedColumns
-    
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_specific_zero_pad_1d(signalBuffer.baseAddress,
-                                 resultBuffer.baseAddress,
-                                 NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
-                                 Int32(padding.top),
-                                 Int32(padding.bottom),
-                                 Int32(padding.left),
-                                 Int32(padding.right))
-      }
-    }
+    var results = [Float](repeating: 0, count: expectedRows * expectedColumns)
+
+    nsc_specific_zero_pad_1d(signal,
+                             &results,
+                             NSC_Size(rows: Int32(inputSize.rows),
+                                      columns: Int32(inputSize.columns)),
+                             Int32(padding.top),
+                             Int32(padding.bottom),
+                             Int32(padding.left),
+                             Int32(padding.right))
+
+    return results
   }
 }

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
@@ -336,36 +336,16 @@ public extension NumSwiftC {
                               b: [Float16],
                               aSize: (rows: Int, columns: Int),
                               bSize: (rows: Int, columns: Int)) -> [Float16] {
-    let count = aSize.rows * bSize.columns
-    return uninitializedArray(count: count) { resultBuffer in
-      a.withUnsafeBufferPointer { aBuffer in
-        b.withUnsafeBufferPointer { bBuffer in
-          nsc_matmul1d_16(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
-                          .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
-                          aBuffer.baseAddress,
-                          bBuffer.baseAddress,
-                          resultBuffer.baseAddress)
-        }
-      }
-    }
-  }
-  
-  public static func matmul1d(_ a: ContiguousArray<Float16>,
-                              b: ContiguousArray<Float16>,
-                              aSize: (rows: Int, columns: Int),
-                              bSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    let count = aSize.rows * bSize.columns
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      a.withUnsafeBufferPointer { aBuffer in
-        b.withUnsafeBufferPointer { bBuffer in
-          nsc_matmul1d_16(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
-                          .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
-                          aBuffer.baseAddress,
-                          bBuffer.baseAddress,
-                          resultBuffer.baseAddress)
-        }
-      }
-    }
+    
+    var results: [Float16] = [Float16](repeating: 0, count: aSize.rows * bSize.columns)
+    
+    nsc_matmul1d_16(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                    .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                    a,
+                    b,
+                    &results)
+    
+    return results
   }
   
   
@@ -495,39 +475,17 @@ public extension NumSwiftC {
     let newRows = rows + ((strides.rows - 1) * (rows - 1))
     let newColumns = columns + ((strides.columns - 1) * (columns - 1))
     
-    let count = newRows * newColumns
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_stride_pad_f16(signalBuffer.baseAddress,
-                           resultBuffer.baseAddress,
-                           NSC_Size(rows: Int32(rows), columns: Int32(columns)),
-                           NSC_Size(rows: Int32(strides.rows), columns: Int32(strides.columns)))
-      }
-    }
-  }
-  
-  static func stridePad1D(signal: ContiguousArray<Float16>,
-                          strides: (rows: Int, columns: Int),
-                          signalSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    guard strides.rows - 1 > 0 || strides.columns - 1 > 0 else {
-      return signal
-    }
+    var results: [Float16] = [Float16](repeating: 0, count: newRows * newColumns)
     
-    let rows = signalSize.rows
-    let columns = signalSize.columns
+    let flatSignal: [Float16] = signal
     
-    let newRows = rows + ((strides.rows - 1) * (rows - 1))
-    let newColumns = columns + ((strides.columns - 1) * (columns - 1))
-    let count = newRows * newColumns
+    nsc_stride_pad_f16(flatSignal,
+                       &results, NSC_Size(rows: Int32(rows),
+                                          columns: Int32(columns)),
+                       NSC_Size(rows: Int32(strides.rows),
+                                columns: Int32(strides.columns)))
     
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_stride_pad_f16(signalBuffer.baseAddress,
-                           resultBuffer.baseAddress,
-                           NSC_Size(rows: Int32(rows), columns: Int32(columns)),
-                           NSC_Size(rows: Int32(strides.rows), columns: Int32(strides.columns)))
-      }
-    }
+    return results
   }
   
   static func zeroPad(signal: [[Float16]],
@@ -653,47 +611,17 @@ public extension NumSwiftC {
     let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
     
     let paddingInt: UInt32 = padding == .valid ? 0 : 1
-    let count = expectedRows * expectedColumns
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_conv1d_f16(signalBuffer.baseAddress,
-                         filterBuffer.baseAddress,
-                         resultBuffer.baseAddress,
-                         NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                         NSC_Padding(rawValue: paddingInt),
-                         NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                         NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
-  }
-  
-  static func conv1d(signal: ContiguousArray<Float16>,
-                     filter: ContiguousArray<Float16>,
-                     strides: (Int, Int) = (1,1),
-                     padding: NumSwift.ConvPadding = .valid,
-                     filterSize: (rows: Int, columns: Int),
-                     inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    let paddingResult = padding.extra(inputSize: inputSize, filterSize: filterSize, stride: strides)
-    let expectedRows = ((inputSize.rows - filterSize.rows + paddingResult.top + paddingResult.bottom) / strides.0) + 1
-    let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
+    var results: [Float16] = [Float16](repeating: 0, count: expectedRows * expectedColumns)
     
-    let paddingInt: UInt32 = padding == .valid ? 0 : 1
-    let count = expectedRows * expectedColumns
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_conv1d_f16(signalBuffer.baseAddress,
-                         filterBuffer.baseAddress,
-                         resultBuffer.baseAddress,
-                         NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                         NSC_Padding(rawValue: paddingInt),
-                         NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                         NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
+    nsc_conv1d_f16(signal,
+                   filter,
+                   &results,
+                   NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                   NSC_Padding(rawValue: paddingInt),
+                   NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                   NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+    
+    return results
   }
   
   static func transConv2d(signal: [[Float16]],
@@ -774,61 +702,17 @@ public extension NumSwiftC {
     
     let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
     let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
-    let count = (rows - (padTop + padBottom)) * (columns - (padLeft + padRight))
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_transConv1d_f16(signalBuffer.baseAddress,
-                              filterBuffer.baseAddress,
-                              resultBuffer.baseAddress,
-                              NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                              NSC_Padding(rawValue: paddingInt),
-                              NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                              NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
-  }
-  
-  static func transConv1d(signal: ContiguousArray<Float16>,
-                          filter: ContiguousArray<Float16>,
-                          strides: (Int, Int) = (1,1),
-                          padding: NumSwift.ConvPadding = .valid,
-                          filterSize: (rows: Int, columns: Int),
-                          inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    let paddingInt: UInt32 = padding == .valid ? 0 : 1
-    var padLeft = 0
-    var padRight = 0
-    var padTop = 0
-    var padBottom = 0
+    var results: [Float16] = [Float16](repeating: 0,
+                                       count: (rows - (padTop + padBottom)) * (columns - (padLeft + padRight)))
     
-    switch padding {
-    case .same:
-      padLeft = Int(floor(Double(filterSize.rows - strides.0) / Double(2)))
-      padRight = filterSize.rows - strides.0 - padLeft
-      padTop = Int(floor(Double(filterSize.columns - strides.1) / Double(2)))
-      padBottom = filterSize.columns - strides.1 - padTop
-      
-    case .valid:
-      break
-    }
-    
-    let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
-    let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
-    let count = (rows - (padTop + padBottom)) * (columns - (padLeft + padRight))
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        filter.withUnsafeBufferPointer { filterBuffer in
-          nsc_transConv1d_f16(signalBuffer.baseAddress,
-                              filterBuffer.baseAddress,
-                              resultBuffer.baseAddress,
-                              NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
-                              NSC_Padding(rawValue: paddingInt),
-                              NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                              NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
-        }
-      }
-    }
+    nsc_transConv1d_f16(signal,
+                        filter,
+                        &results,
+                        NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                        NSC_Padding(rawValue: paddingInt),
+                        NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                        NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+    return results
   }
   
   static func zeroPad(signal: [Float16],
@@ -844,36 +728,19 @@ public extension NumSwiftC {
     
     let count = (inputSize.rows + padding.top + padding.bottom) * (inputSize.columns + padding.left + padding.right)
     
-    return uninitializedArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_zero_pad_f16(signalBuffer.baseAddress,
-                         resultBuffer.baseAddress,
-                         NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                         NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
-                         NSC_Size(rows: Int32(stride.0), columns: Int32(stride.1)))
-      }
-    }
-  }
-  
-  static func zeroPad(signal: ContiguousArray<Float16>,
-                      filterSize: (rows: Int, columns: Int),
-                      inputSize: (rows: Int, columns: Int),
-                      stride: (Int, Int) = (1,1)) -> ContiguousArray<Float16> {
-    let padding = NumSwiftC.paddingCalculation(strides: stride,
-                                               padding: .same,
-                                               filterSize: filterSize,
-                                               inputSize: inputSize)
-    let count = (inputSize.rows + padding.top + padding.bottom) * (inputSize.columns + padding.left + padding.right)
+    var results: [Float16] = [Float16](repeating: 0,
+                                       count: count)
     
-    return uninitializedContiguousArray(count: count) { resultBuffer in
-      signal.withUnsafeBufferPointer { signalBuffer in
-        nsc_zero_pad_f16(signalBuffer.baseAddress,
-                         resultBuffer.baseAddress,
-                         NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
-                         NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
-                         NSC_Size(rows: Int32(stride.0), columns: Int32(stride.1)))
-      }
-    }
+    nsc_zero_pad_f16(signal,
+                     &results,
+                     NSC_Size(rows: Int32(filterSize.rows),
+                              columns: Int32(filterSize.columns)),
+                     NSC_Size(rows: Int32(inputSize.rows),
+                              columns: Int32(inputSize.columns)),
+                     NSC_Size(rows: Int32(stride.0),
+                              columns: Int32(stride.1)))
+    
+    return results
   }
 }
 #endif

--- a/Sources/NumSwift/NumSwiftFlat.swift
+++ b/Sources/NumSwift/NumSwiftFlat.swift
@@ -70,7 +70,7 @@ public enum NumSwiftFlat  {
                             bCols: Int) -> [Float] {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
     
-    let out = NumSwiftC.matmul1d(a, b: b,
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
                                  aSize: (aRows, aCols),
                                  bSize: (bRows, bCols))
     
@@ -104,8 +104,8 @@ public enum NumSwiftFlat  {
                             padding: NumSwift.ConvPadding = .valid,
                             filterSize: (rows: Int, columns: Int),
                             inputSize: (rows: Int, columns: Int)) -> [Float] {
-    let result = NumSwiftC.conv1d(signal: signal,
-                                  filter: filter,
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
                                   strides: strides,
                                   padding: padding,
                                   filterSize: filterSize,
@@ -120,8 +120,8 @@ public enum NumSwiftFlat  {
                                  padding: NumSwift.ConvPadding = .valid,
                                  filterSize: (rows: Int, columns: Int),
                                  inputSize: (rows: Int, columns: Int)) -> [Float] {
-    let result = NumSwiftC.transConv1d(signal: signal,
-                                       filter: filter,
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
                                        strides: strides,
                                        padding: padding,
                                        filterSize: filterSize,
@@ -141,7 +141,7 @@ public enum NumSwiftFlat  {
                              filterSize: (rows: Int, columns: Int),
                              inputSize: (rows: Int, columns: Int),
                              stride: (Int, Int) = (1,1)) -> [Float] {
-    let result = NumSwiftC.zeroPad(signal: signal,
+    let result = NumSwiftC.zeroPad(signal: Array(signal),
                                    filterSize: filterSize,
                                    inputSize: inputSize,
                                    stride: stride)
@@ -234,7 +234,7 @@ public enum NumSwiftFlat  {
                             bCols: Int) -> [Float16] {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
     
-    let out = NumSwiftC.matmul1d(a, b: b,
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
                                  aSize: (aRows, aCols),
                                  bSize: (bRows, bCols))
     
@@ -249,8 +249,8 @@ public enum NumSwiftFlat  {
                             padding: NumSwift.ConvPadding = .valid,
                             filterSize: (rows: Int, columns: Int),
                             inputSize: (rows: Int, columns: Int)) -> [Float16] {
-    let result = NumSwiftC.conv1d(signal: signal,
-                                  filter: filter,
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
                                   strides: strides,
                                   padding: padding,
                                   filterSize: filterSize,
@@ -264,8 +264,8 @@ public enum NumSwiftFlat  {
                                  padding: NumSwift.ConvPadding = .valid,
                                  filterSize: (rows: Int, columns: Int),
                                  inputSize: (rows: Int, columns: Int)) -> [Float16] {
-    let result = NumSwiftC.transConv1d(signal: signal,
-                                       filter: filter,
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
                                        strides: strides,
                                        padding: padding,
                                        filterSize: filterSize,
@@ -404,9 +404,11 @@ extension NumSwiftFlat {
                             bCols: Int) -> ContiguousArray<Float> {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
     
-    return NumSwiftC.matmul1d(a, b: b,
-                              aSize: (aRows, aCols),
-                              bSize: (bRows, bCols))
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
+                                 aSize: (aRows, aCols),
+                                 bSize: (bRows, bCols))
+    
+    return ContiguousArray(out)
   }
   
   // MARK: - Clip
@@ -434,12 +436,13 @@ extension NumSwiftFlat {
                             padding: NumSwift.ConvPadding = .valid,
                             filterSize: (rows: Int, columns: Int),
                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    return NumSwiftC.conv1d(signal: signal,
-                            filter: filter,
-                            strides: strides,
-                            padding: padding,
-                            filterSize: filterSize,
-                            inputSize: inputSize)
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return ContiguousArray(result)
   }
   
   /// Transposed 2D convolution on flat row-major arrays via the C `nsc_transConv1d` function.
@@ -449,19 +452,20 @@ extension NumSwiftFlat {
                                  padding: NumSwift.ConvPadding = .valid,
                                  filterSize: (rows: Int, columns: Int),
                                  inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    return NumSwiftC.transConv1d(signal: signal,
-                                 filter: filter,
-                                 strides: strides,
-                                 padding: padding,
-                                 filterSize: filterSize,
-                                 inputSize: inputSize)
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return ContiguousArray(result)
   }
   
   /// Zero-pad a flat row-major 2D array with explicit padding values.
   public static func zeroPad(signal: ContiguousArray<Float>,
                              padding: NumSwiftPadding,
                              inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    return NumSwiftC.zeroPad1D(signal: signal, padding: padding, inputSize: inputSize)
+    return ContiguousArray(NumSwiftC.zeroPad1D(signal: Array(signal), padding: padding, inputSize: inputSize))
   }
   
   /// Zero-pad a flat row-major 2D array computed from filter/input sizes.
@@ -469,10 +473,11 @@ extension NumSwiftFlat {
                              filterSize: (rows: Int, columns: Int),
                              inputSize: (rows: Int, columns: Int),
                              stride: (Int, Int) = (1,1)) -> ContiguousArray<Float> {
-    return NumSwiftC.zeroPad(signal: signal,
-                             filterSize: filterSize,
-                             inputSize: inputSize,
-                             stride: stride)
+    let result = NumSwiftC.zeroPad(signal: Array(signal),
+                                   filterSize: filterSize,
+                                   inputSize: inputSize,
+                                   stride: stride)
+    return ContiguousArray(result)
   }
   
   /// Stride-pad a flat row-major 2D array (inserts zeros between elements).
@@ -480,7 +485,7 @@ extension NumSwiftFlat {
   public static func stridePad(signal: ContiguousArray<Float>,
                                strides: (rows: Int, columns: Int),
                                inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float> {
-    return NumSwiftC.stridePad1D(signal: signal, strides: strides, signalSize: inputSize)
+    return ContiguousArray(NumSwiftC.stridePad1D(signal: Array(signal), strides: strides, signalSize: inputSize))
   }
   
   /// Flip a flat row-major 2D matrix 180 degrees (reverse all elements, then reverse each row).
@@ -546,9 +551,11 @@ public extension NumSwiftFlat {
                             bCols: Int) -> ContiguousArray<Float16> {
     precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
     
-    return NumSwiftC.matmul1d(a, b: b,
-                              aSize: (aRows, aCols),
-                              bSize: (bRows, bCols))
+    let out = NumSwiftC.matmul1d(Array(a), b: Array(b),
+                                 aSize: (aRows, aCols),
+                                 bSize: (bRows, bCols))
+    
+    return ContiguousArray(out)
   }
   
   // MARK: - Float16 Convolution / Padding
@@ -559,12 +566,13 @@ public extension NumSwiftFlat {
                             padding: NumSwift.ConvPadding = .valid,
                             filterSize: (rows: Int, columns: Int),
                             inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    return NumSwiftC.conv1d(signal: signal,
-                            filter: filter,
-                            strides: strides,
-                            padding: padding,
-                            filterSize: filterSize,
-                            inputSize: inputSize)
+    let result = NumSwiftC.conv1d(signal: Array(signal),
+                                  filter: Array(filter),
+                                  strides: strides,
+                                  padding: padding,
+                                  filterSize: filterSize,
+                                  inputSize: inputSize)
+    return ContiguousArray(result)
   }
   
   public static func transConv2d(signal: ContiguousArray<Float16>,
@@ -573,12 +581,13 @@ public extension NumSwiftFlat {
                                  padding: NumSwift.ConvPadding = .valid,
                                  filterSize: (rows: Int, columns: Int),
                                  inputSize: (rows: Int, columns: Int)) -> ContiguousArray<Float16> {
-    return NumSwiftC.transConv1d(signal: signal,
-                                 filter: filter,
-                                 strides: strides,
-                                 padding: padding,
-                                 filterSize: filterSize,
-                                 inputSize: inputSize)
+    let result = NumSwiftC.transConv1d(signal: Array(signal),
+                                       filter: Array(filter),
+                                       strides: strides,
+                                       padding: padding,
+                                       filterSize: filterSize,
+                                       inputSize: inputSize)
+    return ContiguousArray(result)
   }
   
   public static func zeroPad(signal: ContiguousArray<Float16>,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core numeric kernels (`matmul`, `conv`, padding) and changes how memory is allocated/passed into C, which could affect correctness and performance if the new array bridging/initialization differs from the previous pointer-based approach.
> 
> **Overview**
> Removes the internal `uninitializedArray`/`uninitializedContiguousArray` helpers and the `ContiguousArray` overloads for several C-backed primitives (`matmul1d`, `conv1d`, `transConv1d`, `zeroPad`, `zeroPad1D`, `stridePad1D`) in both `Float` and `Float16` implementations.
> 
> These functions now allocate outputs via `Array(repeating:count:)` and call into the C functions using Swift array bridging (passing inputs as `[Float]/[Float16]` and outputs as `inout` arrays). `NumSwiftFlat` is updated accordingly to convert `ContiguousArray` inputs to `[Array]` and wrap returned arrays back into `ContiguousArray`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45eb0a65646fc5ae1403142b4c58bac12c38a9f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->