### PR TITLE
Batch count support

### DIFF
--- a/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC.swift
@@ -805,6 +805,228 @@ public struct NumSwiftC {
     return results
   }
 
+  // MARK: - Batch Functions
+  
+  public static func conv1dBatch(signal: [Float],
+                                 filter: [Float],
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> [Float] {
+    
+    let paddingResult = padding.extra(inputSize: inputSize, filterSize: filterSize, stride: strides)
+    let expectedRows = ((inputSize.rows - filterSize.rows + paddingResult.top + paddingResult.bottom) / strides.0) + 1
+    let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    var results = [Float](repeating: 0, count: expectedRows * expectedColumns * batchCount)
+    
+    nsc_conv1d_batch(signal,
+                     filter,
+                     &results,
+                     NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                     NSC_Padding(rawValue: paddingInt),
+                     NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                     NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
+                     Int32(batchCount))
+    
+    return results
+  }
+  
+  public static func transConv1dBatch(signal: [Float],
+                                      filter: [Float],
+                                      strides: (Int, Int) = (1,1),
+                                      padding: NumSwift.ConvPadding = .valid,
+                                      filterSize: (rows: Int, columns: Int),
+                                      inputSize: (rows: Int, columns: Int),
+                                      batchCount: Int) -> [Float] {
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    var padLeft = 0
+    var padRight = 0
+    var padTop = 0
+    var padBottom = 0
+    
+    switch padding {
+    case .same:
+      padLeft = Int(floor(Double(filterSize.rows - strides.0) / Double(2)))
+      padRight = filterSize.rows - strides.0 - padLeft
+      padTop = Int(floor(Double(filterSize.columns - strides.1) / Double(2)))
+      padBottom = filterSize.columns - strides.1 - padTop
+    case .valid:
+      break
+    }
+    
+    let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
+    let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
+    let outputElements = (rows - (padTop + padBottom)) * (columns - (padLeft + padRight))
+    var results = [Float](repeating: 0, count: outputElements * batchCount)
+    
+    nsc_transConv1d_batch(signal,
+                          filter,
+                          &results,
+                          NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                          NSC_Padding(rawValue: paddingInt),
+                          NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                          NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
+                          Int32(batchCount))
+    return results
+  }
+  
+  public static func matmul1dBatch(_ a: [Float],
+                                   b: [Float],
+                                   aSize: (rows: Int, columns: Int),
+                                   bSize: (rows: Int, columns: Int),
+                                   batchCount: Int) -> [Float] {
+    
+    var results = [Float](repeating: 0, count: aSize.rows * bSize.columns * batchCount)
+    
+    nsc_matmul1d_batch(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                       .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                       a,
+                       b,
+                       &results,
+                       Int32(batchCount))
+    
+    return results
+  }
+  
+  public static func conv2dBatch(signals: [[[Float]]],
+                                 filter: [[Float]],
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> [[[Float]]] {
+    
+    let paddingResult = padding.extra(inputSize: inputSize, filterSize: filterSize, stride: strides)
+    let expectedRows = ((inputSize.rows - filterSize.rows + paddingResult.top + paddingResult.bottom) / strides.0) + 1
+    let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    
+    var allResults: [[[Float]]] = []
+    allResults.reserveCapacity(batchCount)
+    
+    for b in 0..<batchCount {
+      let result: [[Float]] = NumSwift.zerosLike((expectedRows, expectedColumns))
+      
+      result.withUnsafeBufferPointer { rBuff in
+        signals[b].withUnsafeBufferPointer { sBuff in
+          filter.withUnsafeBufferPointer { fBuff in
+            var rPoint: [UnsafeMutablePointer<Float>?] = rBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let sPoint: [UnsafeMutablePointer<Float>?] = sBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let fPoint: [UnsafeMutablePointer<Float>?] = fBuff.map { UnsafeMutablePointer(mutating: $0) }
+            nsc_conv2d(sPoint,
+                       fPoint,
+                       &rPoint,
+                       NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                       NSC_Padding(rawValue: paddingInt),
+                       NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                       NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+          }
+        }
+      }
+      
+      allResults.append(result)
+    }
+    
+    return allResults
+  }
+  
+  public static func transConv2dBatch(signals: [[[Float]]],
+                                      filter: [[Float]],
+                                      strides: (Int, Int) = (1,1),
+                                      padding: NumSwift.ConvPadding = .valid,
+                                      filterSize: (rows: Int, columns: Int),
+                                      inputSize: (rows: Int, columns: Int),
+                                      batchCount: Int) -> [[[Float]]] {
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    var padLeft = 0
+    var padRight = 0
+    var padTop = 0
+    var padBottom = 0
+    
+    switch padding {
+    case .same:
+      padLeft = Int(floor(Double(filterSize.rows - strides.0) / Double(2)))
+      padRight = filterSize.rows - strides.0 - padLeft
+      padTop = Int(floor(Double(filterSize.columns - strides.1) / Double(2)))
+      padBottom = filterSize.columns - strides.1 - padTop
+    case .valid:
+      break
+    }
+    
+    let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
+    let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
+    
+    var allResults: [[[Float]]] = []
+    allResults.reserveCapacity(batchCount)
+    
+    for b in 0..<batchCount {
+      let result: [[Float]] = NumSwift.zerosLike((rows: (rows - (padTop + padBottom)),
+                                                   columns: (columns - (padLeft + padRight))))
+      
+      result.withUnsafeBufferPointer { rBuff in
+        var rPoint: [UnsafeMutablePointer<Float>?] = rBuff.map { UnsafeMutablePointer(mutating: $0) }
+        
+        signals[b].withUnsafeBufferPointer { aBuff in
+          filter.withUnsafeBufferPointer { bBuff in
+            let signalPoint: [UnsafeMutablePointer<Float>?] = aBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let filterPoint: [UnsafeMutablePointer<Float>?] = bBuff.map { UnsafeMutablePointer(mutating: $0) }
+            nsc_transConv2d(signalPoint,
+                            filterPoint,
+                            &rPoint,
+                            NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                            NSC_Padding(rawValue: paddingInt),
+                            NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                            NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+          }
+        }
+      }
+      
+      allResults.append(result)
+    }
+    
+    return allResults
+  }
+  
+  public static func matmulBatch(_ a: [[[Float]]],
+                                 b: [[Float]],
+                                 aSize: (rows: Int, columns: Int),
+                                 bSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> [[[Float]]] {
+    
+    var allResults: [[[Float]]] = []
+    allResults.reserveCapacity(batchCount)
+    
+    for i in 0..<batchCount {
+      let result: [[Float]] = NumSwift.zerosLike((rows: aSize.rows, columns: bSize.columns))
+      
+      result.withUnsafeBufferPointer { rBuff in
+        var rPoint: [UnsafeMutablePointer<Float>?] = rBuff.map { UnsafeMutablePointer(mutating: $0) }
+        
+        a[i].withUnsafeBufferPointer { aBuff in
+          b.withUnsafeBufferPointer { bBuff in
+            let aPoint: [UnsafeMutablePointer<Float>?] = aBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let bPoint: [UnsafeMutablePointer<Float>?] = bBuff.map { UnsafeMutablePointer(mutating: $0) }
+            nsc_matmul(NSC_Size(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                       NSC_Size(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                       aPoint,
+                       bPoint,
+                       &rPoint)
+          }
+        }
+      }
+      
+      allResults.append(result)
+    }
+    
+    return allResults
+  }
+
   public static func zeroPad1D(signal: [Float],
                                padding: NumSwiftPadding,
                                inputSize: (rows: Int, columns: Int)) -> [Float] {

--- a/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
+++ b/Sources/NumSwift/NumSwiftC/NumSwiftC_Float16.swift
@@ -715,6 +715,228 @@ public extension NumSwiftC {
     return results
   }
   
+  // MARK: - Batch Functions
+  
+  static func conv1dBatch(signal: [Float16],
+                           filter: [Float16],
+                           strides: (Int, Int) = (1,1),
+                           padding: NumSwift.ConvPadding = .valid,
+                           filterSize: (rows: Int, columns: Int),
+                           inputSize: (rows: Int, columns: Int),
+                           batchCount: Int) -> [Float16] {
+    
+    let paddingResult = padding.extra(inputSize: inputSize, filterSize: filterSize, stride: strides)
+    let expectedRows = ((inputSize.rows - filterSize.rows + paddingResult.top + paddingResult.bottom) / strides.0) + 1
+    let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    var results = [Float16](repeating: 0, count: expectedRows * expectedColumns * batchCount)
+    
+    nsc_conv1d_f16_batch(signal,
+                         filter,
+                         &results,
+                         NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                         NSC_Padding(rawValue: paddingInt),
+                         NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                         NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
+                         Int32(batchCount))
+    
+    return results
+  }
+  
+  static func transConv1dBatch(signal: [Float16],
+                                filter: [Float16],
+                                strides: (Int, Int) = (1,1),
+                                padding: NumSwift.ConvPadding = .valid,
+                                filterSize: (rows: Int, columns: Int),
+                                inputSize: (rows: Int, columns: Int),
+                                batchCount: Int) -> [Float16] {
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    var padLeft = 0
+    var padRight = 0
+    var padTop = 0
+    var padBottom = 0
+    
+    switch padding {
+    case .same:
+      padLeft = Int(floor(Double(filterSize.rows - strides.0) / Double(2)))
+      padRight = filterSize.rows - strides.0 - padLeft
+      padTop = Int(floor(Double(filterSize.columns - strides.1) / Double(2)))
+      padBottom = filterSize.columns - strides.1 - padTop
+    case .valid:
+      break
+    }
+    
+    let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
+    let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
+    let outputElements = (rows - (padTop + padBottom)) * (columns - (padLeft + padRight))
+    var results = [Float16](repeating: 0, count: outputElements * batchCount)
+    
+    nsc_transConv1d_f16_batch(signal,
+                              filter,
+                              &results,
+                              NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                              NSC_Padding(rawValue: paddingInt),
+                              NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                              NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)),
+                              Int32(batchCount))
+    return results
+  }
+  
+  static func matmul1dBatch(_ a: [Float16],
+                             b: [Float16],
+                             aSize: (rows: Int, columns: Int),
+                             bSize: (rows: Int, columns: Int),
+                             batchCount: Int) -> [Float16] {
+    
+    var results = [Float16](repeating: 0, count: aSize.rows * bSize.columns * batchCount)
+    
+    nsc_matmul1d_16_batch(.init(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                          .init(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                          a,
+                          b,
+                          &results,
+                          Int32(batchCount))
+    
+    return results
+  }
+  
+  static func conv2dBatch(signals: [[[Float16]]],
+                           filter: [[Float16]],
+                           strides: (Int, Int) = (1,1),
+                           padding: NumSwift.ConvPadding = .valid,
+                           filterSize: (rows: Int, columns: Int),
+                           inputSize: (rows: Int, columns: Int),
+                           batchCount: Int) -> [[[Float16]]] {
+    
+    let paddingResult = padding.extra(inputSize: inputSize, filterSize: filterSize, stride: strides)
+    let expectedRows = ((inputSize.rows - filterSize.rows + paddingResult.top + paddingResult.bottom) / strides.0) + 1
+    let expectedColumns = ((inputSize.columns - filterSize.columns + paddingResult.left + paddingResult.right) / strides.1) + 1
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    
+    var allResults: [[[Float16]]] = []
+    allResults.reserveCapacity(batchCount)
+    
+    for b in 0..<batchCount {
+      let result: [[Float16]] = NumSwift.zerosLike((expectedRows, expectedColumns))
+      
+      result.withUnsafeBufferPointer { rBuff in
+        signals[b].withUnsafeBufferPointer { sBuff in
+          filter.withUnsafeBufferPointer { fBuff in
+            var rPoint: [UnsafeMutablePointer<Float16>?] = rBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let sPoint: [UnsafeMutablePointer<Float16>?] = sBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let fPoint: [UnsafeMutablePointer<Float16>?] = fBuff.map { UnsafeMutablePointer(mutating: $0) }
+            nsc_conv2d_f16(sPoint,
+                           fPoint,
+                           &rPoint,
+                           NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                           NSC_Padding(rawValue: paddingInt),
+                           NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                           NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+          }
+        }
+      }
+      
+      allResults.append(result)
+    }
+    
+    return allResults
+  }
+  
+  static func transConv2dBatch(signals: [[[Float16]]],
+                                filter: [[Float16]],
+                                strides: (Int, Int) = (1,1),
+                                padding: NumSwift.ConvPadding = .valid,
+                                filterSize: (rows: Int, columns: Int),
+                                inputSize: (rows: Int, columns: Int),
+                                batchCount: Int) -> [[[Float16]]] {
+    
+    let paddingInt: UInt32 = padding == .valid ? 0 : 1
+    var padLeft = 0
+    var padRight = 0
+    var padTop = 0
+    var padBottom = 0
+    
+    switch padding {
+    case .same:
+      padLeft = Int(floor(Double(filterSize.rows - strides.0) / Double(2)))
+      padRight = filterSize.rows - strides.0 - padLeft
+      padTop = Int(floor(Double(filterSize.columns - strides.1) / Double(2)))
+      padBottom = filterSize.columns - strides.1 - padTop
+    case .valid:
+      break
+    }
+    
+    let rows = (inputSize.rows - 1) * strides.0 + filterSize.rows
+    let columns = (inputSize.columns - 1) * strides.1 + filterSize.columns
+    
+    var allResults: [[[Float16]]] = []
+    allResults.reserveCapacity(batchCount)
+    
+    for b in 0..<batchCount {
+      let result: [[Float16]] = NumSwift.zerosLike((rows: (rows - (padTop + padBottom)),
+                                                     columns: (columns - (padLeft + padRight))))
+      
+      result.withUnsafeBufferPointer { rBuff in
+        var rPoint: [UnsafeMutablePointer<Float16>?] = rBuff.map { UnsafeMutablePointer(mutating: $0) }
+        
+        signals[b].withUnsafeBufferPointer { aBuff in
+          filter.withUnsafeBufferPointer { bBuff in
+            let signalPoint: [UnsafeMutablePointer<Float16>?] = aBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let filterPoint: [UnsafeMutablePointer<Float16>?] = bBuff.map { UnsafeMutablePointer(mutating: $0) }
+            nsc_transConv2d_f16(signalPoint,
+                                filterPoint,
+                                &rPoint,
+                                NSC_Size(rows: Int32(strides.0), columns: Int32(strides.1)),
+                                NSC_Padding(rawValue: paddingInt),
+                                NSC_Size(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns)),
+                                NSC_Size(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns)))
+          }
+        }
+      }
+      
+      allResults.append(result)
+    }
+    
+    return allResults
+  }
+  
+  static func matmulBatch(_ a: [[[Float16]]],
+                           b: [[Float16]],
+                           aSize: (rows: Int, columns: Int),
+                           bSize: (rows: Int, columns: Int),
+                           batchCount: Int) -> [[[Float16]]] {
+    
+    var allResults: [[[Float16]]] = []
+    allResults.reserveCapacity(batchCount)
+    
+    for i in 0..<batchCount {
+      let result: [[Float16]] = NumSwift.zerosLike((rows: aSize.rows, columns: bSize.columns))
+      
+      result.withUnsafeBufferPointer { rBuff in
+        var rPoint: [UnsafeMutablePointer<Float16>?] = rBuff.map { UnsafeMutablePointer(mutating: $0) }
+        
+        a[i].withUnsafeBufferPointer { aBuff in
+          b.withUnsafeBufferPointer { bBuff in
+            let aPoint: [UnsafeMutablePointer<Float16>?] = aBuff.map { UnsafeMutablePointer(mutating: $0) }
+            let bPoint: [UnsafeMutablePointer<Float16>?] = bBuff.map { UnsafeMutablePointer(mutating: $0) }
+            nsc_matmul_16(NSC_Size(rows: Int32(aSize.rows), columns: Int32(aSize.columns)),
+                          NSC_Size(rows: Int32(bSize.rows), columns: Int32(bSize.columns)),
+                          aPoint,
+                          bPoint,
+                          &rPoint)
+          }
+        }
+      }
+      
+      allResults.append(result)
+    }
+    
+    return allResults
+  }
+
   static func zeroPad(signal: [Float16],
                              filterSize: (rows: Int, columns: Int),
                              inputSize: (rows: Int, columns: Int),

--- a/Sources/NumSwift/NumSwiftFlat.swift
+++ b/Sources/NumSwift/NumSwiftFlat.swift
@@ -188,6 +188,54 @@ public enum NumSwiftFlat  {
     return NumSwiftC.paddingCalculation(strides: strides, padding: padding, filterSize: filterSize, inputSize: inputSize)
   }
   
+  // MARK: - Batch Operations (Float)
+  
+  public static func conv2dBatch(signal: [Float],
+                                 filter: [Float],
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> [Float] {
+    return NumSwiftC.conv1dBatch(signal: signal,
+                                 filter: filter,
+                                 strides: strides,
+                                 padding: padding,
+                                 filterSize: filterSize,
+                                 inputSize: inputSize,
+                                 batchCount: batchCount)
+  }
+  
+  public static func transConv2dBatch(signal: [Float],
+                                      filter: [Float],
+                                      strides: (Int, Int) = (1,1),
+                                      padding: NumSwift.ConvPadding = .valid,
+                                      filterSize: (rows: Int, columns: Int),
+                                      inputSize: (rows: Int, columns: Int),
+                                      batchCount: Int) -> [Float] {
+    return NumSwiftC.transConv1dBatch(signal: signal,
+                                      filter: filter,
+                                      strides: strides,
+                                      padding: padding,
+                                      filterSize: filterSize,
+                                      inputSize: inputSize,
+                                      batchCount: batchCount)
+  }
+  
+  public static func matmulBatch(_ a: [Float],
+                                 _ b: [Float],
+                                 aRows: Int,
+                                 aCols: Int,
+                                 bRows: Int,
+                                 bCols: Int,
+                                 batchCount: Int) -> [Float] {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    return NumSwiftC.matmul1dBatch(a, b: b,
+                                    aSize: (aRows, aCols),
+                                    bSize: (bRows, bCols),
+                                    batchCount: batchCount)
+  }
+  
   #if arch(arm64)
   // Float16 versions use manual loops (no Accelerate support for Float16).
   // The compiler can auto-vectorize these for ARM NEON.
@@ -329,6 +377,54 @@ public enum NumSwiftFlat  {
       }
     }
     return result
+  }
+  
+  // MARK: - Batch Operations (Float16)
+  
+  public static func conv2dBatch(signal: [Float16],
+                                 filter: [Float16],
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> [Float16] {
+    return NumSwiftC.conv1dBatch(signal: signal,
+                                 filter: filter,
+                                 strides: strides,
+                                 padding: padding,
+                                 filterSize: filterSize,
+                                 inputSize: inputSize,
+                                 batchCount: batchCount)
+  }
+  
+  public static func transConv2dBatch(signal: [Float16],
+                                      filter: [Float16],
+                                      strides: (Int, Int) = (1,1),
+                                      padding: NumSwift.ConvPadding = .valid,
+                                      filterSize: (rows: Int, columns: Int),
+                                      inputSize: (rows: Int, columns: Int),
+                                      batchCount: Int) -> [Float16] {
+    return NumSwiftC.transConv1dBatch(signal: signal,
+                                      filter: filter,
+                                      strides: strides,
+                                      padding: padding,
+                                      filterSize: filterSize,
+                                      inputSize: inputSize,
+                                      batchCount: batchCount)
+  }
+  
+  public static func matmulBatch(_ a: [Float16],
+                                 _ b: [Float16],
+                                 aRows: Int,
+                                 aCols: Int,
+                                 bRows: Int,
+                                 bCols: Int,
+                                 batchCount: Int) -> [Float16] {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    return NumSwiftC.matmul1dBatch(a, b: b,
+                                    aSize: (aRows, aCols),
+                                    bSize: (bRows, bCols),
+                                    batchCount: batchCount)
   }
   #endif
 }
@@ -504,6 +600,57 @@ extension NumSwiftFlat {
     return result
   }
   
+  // MARK: - Batch Operations (ContiguousArray<Float>)
+  
+  public static func conv2dBatch(signal: ContiguousArray<Float>,
+                                 filter: ContiguousArray<Float>,
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> ContiguousArray<Float> {
+    let result = NumSwiftC.conv1dBatch(signal: Array(signal),
+                                        filter: Array(filter),
+                                        strides: strides,
+                                        padding: padding,
+                                        filterSize: filterSize,
+                                        inputSize: inputSize,
+                                        batchCount: batchCount)
+    return ContiguousArray(result)
+  }
+  
+  public static func transConv2dBatch(signal: ContiguousArray<Float>,
+                                      filter: ContiguousArray<Float>,
+                                      strides: (Int, Int) = (1,1),
+                                      padding: NumSwift.ConvPadding = .valid,
+                                      filterSize: (rows: Int, columns: Int),
+                                      inputSize: (rows: Int, columns: Int),
+                                      batchCount: Int) -> ContiguousArray<Float> {
+    let result = NumSwiftC.transConv1dBatch(signal: Array(signal),
+                                             filter: Array(filter),
+                                             strides: strides,
+                                             padding: padding,
+                                             filterSize: filterSize,
+                                             inputSize: inputSize,
+                                             batchCount: batchCount)
+    return ContiguousArray(result)
+  }
+  
+  public static func matmulBatch(_ a: ContiguousArray<Float>,
+                                 _ b: ContiguousArray<Float>,
+                                 aRows: Int,
+                                 aCols: Int,
+                                 bRows: Int,
+                                 bCols: Int,
+                                 batchCount: Int) -> ContiguousArray<Float> {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    let result = NumSwiftC.matmul1dBatch(Array(a), b: Array(b),
+                                          aSize: (aRows, aCols),
+                                          bSize: (bRows, bCols),
+                                          batchCount: batchCount)
+    return ContiguousArray(result)
+  }
+  
 }
 
 // MARK: Float 16
@@ -646,6 +793,57 @@ public extension NumSwiftFlat {
       }
     }
     return result
+  }
+  
+  // MARK: - Batch Operations (ContiguousArray<Float16>)
+  
+  public static func conv2dBatch(signal: ContiguousArray<Float16>,
+                                 filter: ContiguousArray<Float16>,
+                                 strides: (Int, Int) = (1,1),
+                                 padding: NumSwift.ConvPadding = .valid,
+                                 filterSize: (rows: Int, columns: Int),
+                                 inputSize: (rows: Int, columns: Int),
+                                 batchCount: Int) -> ContiguousArray<Float16> {
+    let result = NumSwiftC.conv1dBatch(signal: Array(signal),
+                                        filter: Array(filter),
+                                        strides: strides,
+                                        padding: padding,
+                                        filterSize: filterSize,
+                                        inputSize: inputSize,
+                                        batchCount: batchCount)
+    return ContiguousArray(result)
+  }
+  
+  public static func transConv2dBatch(signal: ContiguousArray<Float16>,
+                                      filter: ContiguousArray<Float16>,
+                                      strides: (Int, Int) = (1,1),
+                                      padding: NumSwift.ConvPadding = .valid,
+                                      filterSize: (rows: Int, columns: Int),
+                                      inputSize: (rows: Int, columns: Int),
+                                      batchCount: Int) -> ContiguousArray<Float16> {
+    let result = NumSwiftC.transConv1dBatch(signal: Array(signal),
+                                             filter: Array(filter),
+                                             strides: strides,
+                                             padding: padding,
+                                             filterSize: filterSize,
+                                             inputSize: inputSize,
+                                             batchCount: batchCount)
+    return ContiguousArray(result)
+  }
+  
+  public static func matmulBatch(_ a: ContiguousArray<Float16>,
+                                 _ b: ContiguousArray<Float16>,
+                                 aRows: Int,
+                                 aCols: Int,
+                                 bRows: Int,
+                                 bCols: Int,
+                                 batchCount: Int) -> ContiguousArray<Float16> {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    let result = NumSwiftC.matmul1dBatch(Array(a), b: Array(b),
+                                          aSize: (aRows, aCols),
+                                          bSize: (bRows, bCols),
+                                          batchCount: batchCount)
+    return ContiguousArray(result)
   }
 }
 #endif

--- a/Sources/NumSwift/NumSwiftFlatPointer.swift
+++ b/Sources/NumSwift/NumSwiftFlatPointer.swift
@@ -270,6 +270,64 @@ public extension NumSwiftFlat {
       }
     }
   }
+
+  // MARK: - Batch Operations (Float, pointer-to-pointer)
+
+  /// Batched 2D convolution on flat row-major data.
+  /// Signal contains batchCount inputs packed contiguously. Filter is shared.
+  /// Result must have capacity for batchCount outputs packed contiguously.
+  static func conv2dBatch(signal: UnsafePointer<Float>,
+                          filter: UnsafePointer<Float>,
+                          result: UnsafeMutablePointer<Float>,
+                          strides: (Int, Int) = (1, 1),
+                          padding: NumSwift.ConvPadding = .valid,
+                          filterSize: (rows: Int, columns: Int),
+                          inputSize: (rows: Int, columns: Int),
+                          batchCount: Int) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_conv1d_batch(signal, filter, result,
+                     .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                     nscPadding,
+                     .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                     .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1),
+                     Int32(batchCount))
+  }
+
+  /// Batched transposed 2D convolution on flat row-major data.
+  /// Signal contains batchCount inputs packed contiguously. Filter is shared.
+  static func transConv2dBatch(signal: UnsafePointer<Float>,
+                               filter: UnsafePointer<Float>,
+                               result: UnsafeMutablePointer<Float>,
+                               strides: (Int, Int) = (1, 1),
+                               padding: NumSwift.ConvPadding = .valid,
+                               filterSize: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int),
+                               batchCount: Int) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_transConv1d_batch(signal, filter, result,
+                          .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                          nscPadding,
+                          .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                          .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1),
+                          Int32(batchCount))
+  }
+
+  /// Batched matrix multiplication on flat row-major data.
+  /// `a` contains batchCount matrices packed contiguously. `b` is shared.
+  static func matmulBatch(_ a: UnsafePointer<Float>,
+                          _ b: UnsafePointer<Float>,
+                          result: UnsafeMutablePointer<Float>,
+                          aRows: Int,
+                          aCols: Int,
+                          bRows: Int,
+                          bCols: Int,
+                          batchCount: Int) {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    nsc_matmul1d_batch(.init(rows: Int32(aRows), columns: Int32(aCols), depth: 1),
+                       .init(rows: Int32(bRows), columns: Int32(bCols), depth: 1),
+                       a, b, result,
+                       Int32(batchCount))
+  }
 }
 
 // MARK: - Float16 Pointer APIs
@@ -520,6 +578,60 @@ public extension NumSwiftFlat {
         result[dstStart + c] = signal[srcStart + (columns - 1 - c)]
       }
     }
+  }
+
+  // MARK: - Batch Operations (Float16, pointer-to-pointer)
+
+  /// Batched 2D convolution on flat row-major Float16 data.
+  static func conv2dBatch(signal: UnsafePointer<Float16>,
+                          filter: UnsafePointer<Float16>,
+                          result: UnsafeMutablePointer<Float16>,
+                          strides: (Int, Int) = (1, 1),
+                          padding: NumSwift.ConvPadding = .valid,
+                          filterSize: (rows: Int, columns: Int),
+                          inputSize: (rows: Int, columns: Int),
+                          batchCount: Int) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_conv1d_f16_batch(signal, filter, result,
+                         .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                         nscPadding,
+                         .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                         .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1),
+                         Int32(batchCount))
+  }
+
+  /// Batched transposed 2D convolution on flat row-major Float16 data.
+  static func transConv2dBatch(signal: UnsafePointer<Float16>,
+                               filter: UnsafePointer<Float16>,
+                               result: UnsafeMutablePointer<Float16>,
+                               strides: (Int, Int) = (1, 1),
+                               padding: NumSwift.ConvPadding = .valid,
+                               filterSize: (rows: Int, columns: Int),
+                               inputSize: (rows: Int, columns: Int),
+                               batchCount: Int) {
+    let nscPadding: NSC_Padding = padding == .same ? same : valid
+    nsc_transConv1d_f16_batch(signal, filter, result,
+                              .init(rows: Int32(strides.0), columns: Int32(strides.1), depth: 1),
+                              nscPadding,
+                              .init(rows: Int32(filterSize.rows), columns: Int32(filterSize.columns), depth: 1),
+                              .init(rows: Int32(inputSize.rows), columns: Int32(inputSize.columns), depth: 1),
+                              Int32(batchCount))
+  }
+
+  /// Batched matrix multiplication on flat row-major Float16 data.
+  static func matmulBatch(_ a: UnsafePointer<Float16>,
+                          _ b: UnsafePointer<Float16>,
+                          result: UnsafeMutablePointer<Float16>,
+                          aRows: Int,
+                          aCols: Int,
+                          bRows: Int,
+                          bCols: Int,
+                          batchCount: Int) {
+    precondition(aCols == bRows, "A columns (\(aCols)) must equal B rows (\(bRows))")
+    nsc_matmul1d_16_batch(.init(rows: Int32(aRows), columns: Int32(aCols), depth: 1),
+                          .init(rows: Int32(bRows), columns: Int32(bCols), depth: 1),
+                          a, b, result,
+                          Int32(batchCount))
   }
 }
 #endif

--- a/Sources/NumSwiftC/include/numswiftc.h
+++ b/Sources/NumSwiftC/include/numswiftc.h
@@ -206,3 +206,110 @@ extern void nsc_padding_calculation(NSC_Size stride,
                                     int *paddingBottom,
                                     int *paddingLeft,
                                     int *paddingRight);
+
+// MARK: - Batch Functions
+// Flat (1D) batch: signals/results are contiguous batches of batchCount items.
+// Filter/weights are shared across all batch items.
+
+extern void nsc_conv1d_batch(const float signal[],
+                             const float filter[],
+                             float *result,
+                             NSC_Size stride,
+                             NSC_Padding padding,
+                             NSC_Size filter_size,
+                             NSC_Size input_size,
+                             int batch_count);
+
+extern void nsc_conv1d_f16_batch(const __fp16 signal[],
+                                 const __fp16 filter[],
+                                 __fp16 *result,
+                                 NSC_Size stride,
+                                 NSC_Padding padding,
+                                 NSC_Size filter_size,
+                                 NSC_Size input_size,
+                                 int batch_count);
+
+extern void nsc_transConv1d_batch(const float signal[],
+                                  const float filter[],
+                                  float *result,
+                                  NSC_Size stride,
+                                  NSC_Padding padding,
+                                  NSC_Size filter_size,
+                                  NSC_Size input_size,
+                                  int batch_count);
+
+extern void nsc_transConv1d_f16_batch(const __fp16 signal[],
+                                      const __fp16 filter[],
+                                      __fp16 *result,
+                                      NSC_Size stride,
+                                      NSC_Padding padding,
+                                      NSC_Size filter_size,
+                                      NSC_Size input_size,
+                                      int batch_count);
+
+extern void nsc_matmul1d_batch(NSC_Size a_size,
+                               NSC_Size b_size,
+                               const float a[],
+                               const float b[],
+                               float *result,
+                               int batch_count);
+
+extern void nsc_matmul1d_16_batch(NSC_Size a_size,
+                                  NSC_Size b_size,
+                                  const __fp16 a[],
+                                  const __fp16 b[],
+                                  __fp16 *result,
+                                  int batch_count);
+
+// 2D pointer batch: signals[batchIndex][row][col], results[batchIndex][row][col].
+// Filter/weights are shared across all batch items.
+
+extern void nsc_conv2d_batch(float *const *const *signals,
+                             float *const *filter,
+                             float ***results,
+                             NSC_Size stride,
+                             NSC_Padding padding,
+                             NSC_Size filter_size,
+                             NSC_Size input_size,
+                             int batch_count);
+
+extern void nsc_conv2d_f16_batch(__fp16 *const *const *signals,
+                                 __fp16 *const *filter,
+                                 __fp16 ***results,
+                                 NSC_Size stride,
+                                 NSC_Padding padding,
+                                 NSC_Size filter_size,
+                                 NSC_Size input_size,
+                                 int batch_count);
+
+extern void nsc_transConv2d_batch(float *const *const *signals,
+                                  float *const *filter,
+                                  float ***results,
+                                  NSC_Size stride,
+                                  NSC_Padding padding,
+                                  NSC_Size filter_size,
+                                  NSC_Size input_size,
+                                  int batch_count);
+
+extern void nsc_transConv2d_f16_batch(__fp16 *const *const *signals,
+                                      __fp16 *const *filter,
+                                      __fp16 ***results,
+                                      NSC_Size stride,
+                                      NSC_Padding padding,
+                                      NSC_Size filter_size,
+                                      NSC_Size input_size,
+                                      int batch_count);
+
+extern void nsc_matmul_batch(NSC_Size a_size,
+                             NSC_Size b_size,
+                             float *const *const *a,
+                             float *const *b,
+                             float ***result,
+                             int batch_count);
+
+extern void nsc_matmul_16_batch(NSC_Size a_size,
+                                NSC_Size b_size,
+                                __fp16 *const *const *a,
+                                __fp16 *const *b,
+                                __fp16 ***result,
+                                int batch_count);

--- a/Sources/NumSwiftC/numswiftc.c
+++ b/Sources/NumSwiftC/numswiftc.c
@@ -2400,3 +2400,273 @@ extern void nsc_transConv1d(const float signal[],
 
   memcpy(result, padded, padded_col_total * padded_row_total * sizeof(float));
 }
+
+// MARK: - Batch Functions
+
+extern void nsc_conv1d_batch(const float signal[],
+                             const float filter[],
+                             float *result,
+                             NSC_Size stride,
+                             NSC_Padding padding,
+                             NSC_Size filter_size,
+                             NSC_Size input_size,
+                             int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  int paddingLeft, paddingRight, paddingBottom, paddingTop;
+  nsc_padding_calculation(stride, padding, filter_size, input_size,
+                          &paddingTop, &paddingBottom, &paddingLeft, &paddingRight);
+
+  int input_elements = input_size.rows * input_size.columns;
+  int expected_r = ((input_size.rows - filter_size.rows + paddingTop + paddingBottom) / stride.rows) + 1;
+  int expected_c = ((input_size.columns - filter_size.columns + paddingLeft + paddingRight) / stride.columns) + 1;
+  int output_elements = expected_r * expected_c;
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_conv1d(&signal[b * input_elements],
+               filter,
+               &result[b * output_elements],
+               stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_conv1d_f16_batch(const __fp16 signal[],
+                                 const __fp16 filter[],
+                                 __fp16 *result,
+                                 NSC_Size stride,
+                                 NSC_Padding padding,
+                                 NSC_Size filter_size,
+                                 NSC_Size input_size,
+                                 int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  int paddingLeft, paddingRight, paddingBottom, paddingTop;
+  nsc_padding_calculation(stride, padding, filter_size, input_size,
+                          &paddingTop, &paddingBottom, &paddingLeft, &paddingRight);
+
+  int input_elements = input_size.rows * input_size.columns;
+  int expected_r = ((input_size.rows - filter_size.rows + paddingTop + paddingBottom) / stride.rows) + 1;
+  int expected_c = ((input_size.columns - filter_size.columns + paddingLeft + paddingRight) / stride.columns) + 1;
+  int output_elements = expected_r * expected_c;
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_conv1d_f16(&signal[b * input_elements],
+                   filter,
+                   &result[b * output_elements],
+                   stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_transConv1d_batch(const float signal[],
+                                  const float filter[],
+                                  float *result,
+                                  NSC_Size stride,
+                                  NSC_Padding padding,
+                                  NSC_Size filter_size,
+                                  NSC_Size input_size,
+                                  int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  int strideR = stride.rows;
+  int strideC = stride.columns;
+  int filterRows = filter_size.rows;
+  int filterColumns = filter_size.columns;
+
+  int rows = (input_size.rows - 1) * strideR + filterRows;
+  int columns = (input_size.columns - 1) * strideC + filterColumns;
+
+  int pad_left = 0, pad_right = 0, pad_top = 0, pad_bottom = 0;
+  if (padding == same) {
+    pad_left = (int)floor(((double)filterRows - (double)strideR) / 2.0);
+    pad_right = filterRows - strideR - pad_left;
+    pad_top = (int)floor(((double)filterColumns - (double)strideC) / 2.0);
+    pad_bottom = filterColumns - strideC - pad_top;
+  }
+
+  int input_elements = input_size.rows * input_size.columns;
+  int output_elements = (rows - (pad_top + pad_bottom)) * (columns - (pad_left + pad_right));
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_transConv1d(&signal[b * input_elements],
+                    filter,
+                    &result[b * output_elements],
+                    stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_transConv1d_f16_batch(const __fp16 signal[],
+                                      const __fp16 filter[],
+                                      __fp16 *result,
+                                      NSC_Size stride,
+                                      NSC_Padding padding,
+                                      NSC_Size filter_size,
+                                      NSC_Size input_size,
+                                      int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  int strideR = stride.rows;
+  int strideC = stride.columns;
+  int filterRows = filter_size.rows;
+  int filterColumns = filter_size.columns;
+
+  int rows = (input_size.rows - 1) * strideR + filterRows;
+  int columns = (input_size.columns - 1) * strideC + filterColumns;
+
+  int pad_left = 0, pad_right = 0, pad_top = 0, pad_bottom = 0;
+  if (padding == same) {
+    pad_left = (int)floor(((double)filterRows - (double)strideR) / 2.0);
+    pad_right = filterRows - strideR - pad_left;
+    pad_top = (int)floor(((double)filterColumns - (double)strideC) / 2.0);
+    pad_bottom = filterColumns - strideC - pad_top;
+  }
+
+  int input_elements = input_size.rows * input_size.columns;
+  int output_elements = (rows - (pad_top + pad_bottom)) * (columns - (pad_left + pad_right));
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_transConv1d_f16(&signal[b * input_elements],
+                        filter,
+                        &result[b * output_elements],
+                        stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_matmul1d_batch(NSC_Size a_size,
+                               NSC_Size b_size,
+                               const float a[],
+                               const float b[],
+                               float *result,
+                               int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  int a_elements = a_size.rows * a_size.columns;
+  int result_elements = a_size.rows * b_size.columns;
+
+  for (int i = 0; i < batch_count; i++) {
+    nsc_matmul1d(a_size, b_size,
+                 &a[i * a_elements],
+                 b,
+                 &result[i * result_elements]);
+  }
+}
+
+extern void nsc_matmul1d_16_batch(NSC_Size a_size,
+                                  NSC_Size b_size,
+                                  const __fp16 a[],
+                                  const __fp16 b[],
+                                  __fp16 *result,
+                                  int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  int a_elements = a_size.rows * a_size.columns;
+  int result_elements = a_size.rows * b_size.columns;
+
+  for (int i = 0; i < batch_count; i++) {
+    nsc_matmul1d_16(a_size, b_size,
+                    &a[i * a_elements],
+                    b,
+                    &result[i * result_elements]);
+  }
+}
+
+extern void nsc_conv2d_batch(float *const *const *signals,
+                             float *const *filter,
+                             float ***results,
+                             NSC_Size stride,
+                             NSC_Padding padding,
+                             NSC_Size filter_size,
+                             NSC_Size input_size,
+                             int batch_count) {
+  if (results == NULL || batch_count <= 0)
+    return;
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_conv2d(signals[b], filter, results[b],
+               stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_conv2d_f16_batch(__fp16 *const *const *signals,
+                                 __fp16 *const *filter,
+                                 __fp16 ***results,
+                                 NSC_Size stride,
+                                 NSC_Padding padding,
+                                 NSC_Size filter_size,
+                                 NSC_Size input_size,
+                                 int batch_count) {
+  if (results == NULL || batch_count <= 0)
+    return;
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_conv2d_f16(signals[b], filter, results[b],
+                   stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_transConv2d_batch(float *const *const *signals,
+                                  float *const *filter,
+                                  float ***results,
+                                  NSC_Size stride,
+                                  NSC_Padding padding,
+                                  NSC_Size filter_size,
+                                  NSC_Size input_size,
+                                  int batch_count) {
+  if (results == NULL || batch_count <= 0)
+    return;
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_transConv2d(signals[b], filter, results[b],
+                    stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_transConv2d_f16_batch(__fp16 *const *const *signals,
+                                      __fp16 *const *filter,
+                                      __fp16 ***results,
+                                      NSC_Size stride,
+                                      NSC_Padding padding,
+                                      NSC_Size filter_size,
+                                      NSC_Size input_size,
+                                      int batch_count) {
+  if (results == NULL || batch_count <= 0)
+    return;
+
+  for (int b = 0; b < batch_count; b++) {
+    nsc_transConv2d_f16(signals[b], filter, results[b],
+                        stride, padding, filter_size, input_size);
+  }
+}
+
+extern void nsc_matmul_batch(NSC_Size a_size,
+                             NSC_Size b_size,
+                             float *const *const *a,
+                             float *const *b,
+                             float ***result,
+                             int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  for (int i = 0; i < batch_count; i++) {
+    nsc_matmul(a_size, b_size, a[i], b, result[i]);
+  }
+}
+
+extern void nsc_matmul_16_batch(NSC_Size a_size,
+                                NSC_Size b_size,
+                                __fp16 *const *const *a,
+                                __fp16 *const *b,
+                                __fp16 ***result,
+                                int batch_count) {
+  if (result == NULL || batch_count <= 0)
+    return;
+
+  for (int i = 0; i < batch_count; i++) {
+    nsc_matmul_16(a_size, b_size, a[i], b, result[i]);
+  }
+}

--- a/Tests/NumSwiftTests/BatchTests.swift
+++ b/Tests/NumSwiftTests/BatchTests.swift
@@ -21,7 +21,7 @@ final class BatchTests: XCTestCase {
     let single2 = NumSwiftC.conv1d(signal: signal2, filter: filter, strides: (1,1),
                                     padding: .same, filterSize: filterSize, inputSize: inputSize)
 
-    let batchedSignal = signal1 + signal2
+    let batchedSignal = [signal1, signal2].flatMap { $0 }
     let batchResult = NumSwiftC.conv1dBatch(signal: batchedSignal, filter: filter,
                                              strides: (1,1), padding: .same,
                                              filterSize: filterSize, inputSize: inputSize,
@@ -42,7 +42,7 @@ final class BatchTests: XCTestCase {
                            0, 0, 1]
 
     let signal: [Float] = [[Float]](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
-    let batchedSignal = signal + signal + signal
+    let batchedSignal = [signal, signal, signal].flatMap { $0 }
 
     let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
                                    padding: .valid, filterSize: filterSize, inputSize: inputSize)
@@ -106,7 +106,7 @@ final class BatchTests: XCTestCase {
     let single2 = NumSwiftC.transConv1d(signal: signal2, filter: filter, strides: (1,1),
                                          padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchedSignal = signal1 + signal2
+    let batchedSignal = [signal1, signal2].flatMap { $0 }
     let batchResult = NumSwiftC.transConv1dBatch(signal: batchedSignal, filter: filter,
                                                   strides: (1,1), padding: .valid,
                                                   filterSize: filterSize, inputSize: inputSize,
@@ -131,7 +131,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftC.transConv1d(signal: signal, filter: filter, strides: (1,1),
                                         padding: .same, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftC.transConv1dBatch(signal: signal + signal, filter: filter,
+    let batchResult = NumSwiftC.transConv1dBatch(signal: [signal, signal].flatMap { $0 }, filter: filter,
                                                   strides: (1,1), padding: .same,
                                                   filterSize: filterSize, inputSize: inputSize,
                                                   batchCount: 2)
@@ -190,7 +190,7 @@ final class BatchTests: XCTestCase {
     let single1 = NumSwiftC.matmul1d(a1, b: b, aSize: aSize, bSize: bSize)
     let single2 = NumSwiftC.matmul1d(a2, b: b, aSize: aSize, bSize: bSize)
 
-    let batchedA = a1 + a2
+    let batchedA = [a1, a2].flatMap { $0 }
     let batchResult = NumSwiftC.matmul1dBatch(batchedA, b: b, aSize: aSize, bSize: bSize, batchCount: 2)
 
     let outputSize = single1.count
@@ -257,7 +257,7 @@ final class BatchTests: XCTestCase {
     let single2 = NumSwiftFlat.conv2d(signal: signal2, filter: filter, strides: (1,1),
                                        padding: .same, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftFlat.conv2dBatch(signal: signal1 + signal2, filter: filter,
+    let batchResult = NumSwiftFlat.conv2dBatch(signal: [signal1, signal2].flatMap { $0 }, filter: filter,
                                                 strides: (1,1), padding: .same,
                                                 filterSize: filterSize, inputSize: inputSize,
                                                 batchCount: 2)
@@ -281,7 +281,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftFlat.transConv2d(signal: signal, filter: filter, strides: (1,1),
                                            padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftFlat.transConv2dBatch(signal: signal + signal, filter: filter,
+    let batchResult = NumSwiftFlat.transConv2dBatch(signal: [signal, signal].flatMap { $0 }, filter: filter,
                                                      strides: (1,1), padding: .valid,
                                                      filterSize: filterSize, inputSize: inputSize,
                                                      batchCount: 2)
@@ -300,7 +300,7 @@ final class BatchTests: XCTestCase {
     let single1 = NumSwiftFlat.matmul(a1, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
     let single2 = NumSwiftFlat.matmul(a2, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
 
-    let batchResult = NumSwiftFlat.matmulBatch(a1 + a2, b, aRows: 2, aCols: 3,
+    let batchResult = NumSwiftFlat.matmulBatch([a1, a2].flatMap { $0 }, b, aRows: 2, aCols: 3,
                                                 bRows: 3, bCols: 2, batchCount: 2)
 
     let outputSize = single1.count
@@ -321,7 +321,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftFlat.conv2d(signal: signal, filter: filter, strides: (1,1),
                                       padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchSignal = signal + signal
+    let batchSignal = ContiguousArray([signal, signal].flatMap { $0 })
     let batchResult = NumSwiftFlat.conv2dBatch(signal: batchSignal, filter: filter,
                                                 strides: (1,1), padding: .valid,
                                                 filterSize: filterSize, inputSize: inputSize,
@@ -343,7 +343,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftFlat.transConv2d(signal: signal, filter: filter, strides: (1,1),
                                            padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftFlat.transConv2dBatch(signal: signal + signal, filter: filter,
+    let batchResult = NumSwiftFlat.transConv2dBatch(signal: ContiguousArray([signal, signal].flatMap { $0 }), filter: filter,
                                                      strides: (1,1), padding: .valid,
                                                      filterSize: filterSize, inputSize: inputSize,
                                                      batchCount: 2)
@@ -360,7 +360,7 @@ final class BatchTests: XCTestCase {
 
     let single = NumSwiftFlat.matmul(a, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
 
-    let batchResult = NumSwiftFlat.matmulBatch(a + a, b, aRows: 2, aCols: 3,
+    let batchResult = NumSwiftFlat.matmulBatch(ContiguousArray([a, a].flatMap { $0 }), b, aRows: 2, aCols: 3,
                                                 bRows: 3, bCols: 2, batchCount: 2)
 
     let outputSize = single.count
@@ -387,7 +387,7 @@ final class BatchTests: XCTestCase {
     let single2 = NumSwiftC.conv1d(signal: signal2, filter: filter, strides: (1,1),
                                     padding: .same, filterSize: filterSize, inputSize: inputSize)
 
-    let batchedSignal = signal1 + signal2
+    let batchedSignal = [signal1, signal2].flatMap { $0 }
     let outputSize = single1.count
     var result = [Float](repeating: 0, count: outputSize * 2)
 
@@ -418,7 +418,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftC.transConv1d(signal: signal, filter: filter, strides: (1,1),
                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchedSignal = signal + signal
+    let batchedSignal = [signal, signal].flatMap { $0 }
     let outputSize = single.count
     var result = [Float](repeating: 0, count: outputSize * 2)
 
@@ -444,7 +444,7 @@ final class BatchTests: XCTestCase {
     let single1 = NumSwiftC.matmul1d(a1, b: b, aSize: (2, 3), bSize: (3, 2))
     let single2 = NumSwiftC.matmul1d(a2, b: b, aSize: (2, 3), bSize: (3, 2))
 
-    let batchedA = a1 + a2
+    let batchedA = [a1, a2].flatMap { $0 }
     let outputSize = single1.count
     var result = [Float](repeating: 0, count: outputSize * 2)
 
@@ -517,7 +517,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (2,2),
                                    padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftC.conv1dBatch(signal: signal + signal, filter: filter,
+    let batchResult = NumSwiftC.conv1dBatch(signal: [signal, signal].flatMap { $0 }, filter: filter,
                                              strides: (2,2), padding: .valid,
                                              filterSize: filterSize, inputSize: inputSize,
                                              batchCount: 2)
@@ -624,7 +624,7 @@ final class BatchTests: XCTestCase {
     let single2 = NumSwiftC.conv1d(signal: signal2, filter: filter, strides: (1,1),
                                     padding: .same, filterSize: filterSize, inputSize: inputSize)
 
-    let batchedSignal = signal1 + signal2
+    let batchedSignal: [Float16] = [signal1, signal2].flatMap { $0 }
     let batchResult = NumSwiftC.conv1dBatch(signal: batchedSignal, filter: filter,
                                              strides: (1,1), padding: .same,
                                              filterSize: filterSize, inputSize: inputSize,
@@ -674,7 +674,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftC.transConv1d(signal: signal, filter: filter, strides: (1,1),
                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftC.transConv1dBatch(signal: signal + signal, filter: filter,
+    let batchResult = NumSwiftC.transConv1dBatch(signal: [signal, signal].flatMap { $0 }, filter: filter,
                                                   strides: (1,1), padding: .valid,
                                                   filterSize: filterSize, inputSize: inputSize,
                                                   batchCount: 2)
@@ -723,7 +723,7 @@ final class BatchTests: XCTestCase {
     let single1 = NumSwiftC.matmul1d(a1, b: b, aSize: aSize, bSize: bSize)
     let single2 = NumSwiftC.matmul1d(a2, b: b, aSize: aSize, bSize: bSize)
 
-    let batchResult = NumSwiftC.matmul1dBatch(a1 + a2, b: b, aSize: aSize, bSize: bSize, batchCount: 2)
+    let batchResult = NumSwiftC.matmul1dBatch([a1, a2].flatMap { $0 }, b: b, aSize: aSize, bSize: bSize, batchCount: 2)
 
     let outputSize = single1.count
     XCTAssertEqual(batchResult.count, outputSize * 2)
@@ -759,7 +759,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftFlat.conv2d(signal: signal, filter: filter, strides: (1,1),
                                       padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchResult = NumSwiftFlat.conv2dBatch(signal: signal + signal, filter: filter,
+    let batchResult = NumSwiftFlat.conv2dBatch(signal: [signal, signal].flatMap { $0 }, filter: filter,
                                                 strides: (1,1), padding: .valid,
                                                 filterSize: filterSize, inputSize: inputSize,
                                                 batchCount: 2)
@@ -776,7 +776,7 @@ final class BatchTests: XCTestCase {
 
     let single = NumSwiftFlat.matmul(a, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
 
-    let batchResult = NumSwiftFlat.matmulBatch(a + a, b, aRows: 2, aCols: 3,
+    let batchResult = NumSwiftFlat.matmulBatch([a, a].flatMap { $0 }, b, aRows: 2, aCols: 3,
                                                 bRows: 3, bCols: 2, batchCount: 2)
 
     let outputSize = single.count
@@ -795,7 +795,7 @@ final class BatchTests: XCTestCase {
     let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
                                    padding: .valid, filterSize: filterSize, inputSize: inputSize)
 
-    let batchedSignal = signal + signal
+    let batchedSignal: [Float16] = [signal, signal].flatMap { $0 }
     let outputSize = single.count
     var result = [Float16](repeating: 0, count: outputSize * 2)
 
@@ -819,7 +819,7 @@ final class BatchTests: XCTestCase {
 
     let single = NumSwiftC.matmul1d(a, b: b, aSize: (2, 3), bSize: (3, 2))
 
-    let batchedA = a + a
+    let batchedA: [Float16] = [a, a].flatMap { $0 }
     let outputSize = single.count
     var result = [Float16](repeating: 0, count: outputSize * 2)
 

--- a/Tests/NumSwiftTests/BatchTests.swift
+++ b/Tests/NumSwiftTests/BatchTests.swift
@@ -1,0 +1,841 @@
+import XCTest
+@testable import NumSwift
+
+final class BatchTests: XCTestCase {
+
+  // MARK: - NumSwiftC conv1dBatch (flat Float)
+
+  func test_conv1dBatch_matchesSingleCalls() {
+    let inputSize = (rows: 5, columns: 5)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [0, 1, 0,
+                           0, 1, 0,
+                           0, 1, 0]
+
+    let signal1: [Float] = [Float](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+
+    let single1 = NumSwiftC.conv1d(signal: signal1, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.conv1d(signal: signal2, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    let batchedSignal = signal1 + signal2
+    let batchResult = NumSwiftC.conv1dBatch(signal: batchedSignal, filter: filter,
+                                             strides: (1,1), padding: .same,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 2)
+
+    let expectedCount = single1.count + single2.count
+    XCTAssertEqual(batchResult.count, expectedCount)
+    XCTAssertEqual(Array(batchResult[0..<single1.count]), single1)
+    XCTAssertEqual(Array(batchResult[single1.count..<expectedCount]), single2)
+  }
+
+  func test_conv1dBatch_validPadding() {
+    let inputSize = (rows: 5, columns: 5)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [1, 0, 0,
+                           0, 1, 0,
+                           0, 0, 1]
+
+    let signal: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+    let batchedSignal = signal + signal + signal
+
+    let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
+                                   padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.conv1dBatch(signal: batchedSignal, filter: filter,
+                                             strides: (1,1), padding: .valid,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 3)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 3)
+    for b in 0..<3 {
+      XCTAssertEqual(Array(batchResult[b * outputSize..<(b + 1) * outputSize]), single,
+                     "Batch item \(b) mismatch")
+    }
+  }
+
+  // MARK: - NumSwiftC conv2dBatch (2D Float)
+
+  func test_conv2dBatch_matchesSingleCalls() {
+    let inputSize = (rows: 5, columns: 5)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [[Float]] = [[0, 1, 0],
+                              [0, 1, 0],
+                              [0, 1, 0]]
+
+    let signal1: [[Float]] = [[Float]](repeating: [0,0,1,0,0], count: 5)
+    let signal2: [[Float]] = [[Float]](repeating: [1,0,0,0,1], count: 5)
+
+    let single1 = NumSwiftC.conv2d(signal: signal1, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.conv2d(signal: signal2, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.conv2dBatch(signals: [signal1, signal2], filter: filter,
+                                             strides: (1,1), padding: .same,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], single1)
+    XCTAssertEqual(batchResult[1], single2)
+  }
+
+  // MARK: - NumSwiftC transConv1dBatch (flat Float)
+
+  func test_transConv1dBatch_matchesSingleCalls() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [1, 0, 0,
+                           0, 1, 0,
+                           0, 0, 1]
+
+    let signal1: [Float] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+    let signal2: [Float] = [0, 1, 0, 1, 0, 1, 0, 1, 0]
+
+    let single1 = NumSwiftC.transConv1d(signal: signal1, filter: filter, strides: (1,1),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.transConv1d(signal: signal2, filter: filter, strides: (1,1),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchedSignal = signal1 + signal2
+    let batchResult = NumSwiftC.transConv1dBatch(signal: batchedSignal, filter: filter,
+                                                  strides: (1,1), padding: .valid,
+                                                  filterSize: filterSize, inputSize: inputSize,
+                                                  batchCount: 2)
+
+    let outputSize = single1.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single1)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single2)
+  }
+
+  func test_transConv1dBatch_samePadding() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [1, 1, 1,
+                           1, 1, 1,
+                           1, 1, 1]
+
+    let signal: [Float] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    let single = NumSwiftC.transConv1d(signal: signal, filter: filter, strides: (1,1),
+                                        padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.transConv1dBatch(signal: signal + signal, filter: filter,
+                                                  strides: (1,1), padding: .same,
+                                                  filterSize: filterSize, inputSize: inputSize,
+                                                  batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  // MARK: - NumSwiftC transConv2dBatch (2D Float)
+
+  func test_transConv2dBatch_matchesSingleCalls() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [[Float]] = [[1, 0, 0],
+                              [0, 1, 0],
+                              [0, 0, 1]]
+
+    let signal1: [[Float]] = [[1, 0, 0],
+                               [0, 1, 0],
+                               [0, 0, 1]]
+    let signal2: [[Float]] = [[0, 1, 0],
+                               [1, 0, 1],
+                               [0, 1, 0]]
+
+    let single1 = NumSwiftC.transConv2d(signal: signal1, filter: filter, strides: (1,1),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.transConv2d(signal: signal2, filter: filter, strides: (1,1),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.transConv2dBatch(signals: [signal1, signal2], filter: filter,
+                                                  strides: (1,1), padding: .valid,
+                                                  filterSize: filterSize, inputSize: inputSize,
+                                                  batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], single1)
+    XCTAssertEqual(batchResult[1], single2)
+  }
+
+  // MARK: - NumSwiftC matmul1dBatch (flat Float)
+
+  func test_matmul1dBatch_matchesSingleCalls() {
+    let aSize = (rows: 3, columns: 3)
+    let bSize = (rows: 3, columns: 2)
+
+    let b: [Float] = [2, 2,
+                      2, 2,
+                      2, 2]
+
+    let a1: [Float] = [1, 1, 1, 2, 2, 2, 3, 3, 3]
+    let a2: [Float] = [4, 4, 4, 5, 5, 5, 6, 6, 6]
+
+    let single1 = NumSwiftC.matmul1d(a1, b: b, aSize: aSize, bSize: bSize)
+    let single2 = NumSwiftC.matmul1d(a2, b: b, aSize: aSize, bSize: bSize)
+
+    let batchedA = a1 + a2
+    let batchResult = NumSwiftC.matmul1dBatch(batchedA, b: b, aSize: aSize, bSize: bSize, batchCount: 2)
+
+    let outputSize = single1.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single1)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single2)
+  }
+
+  func test_matmul1dBatch_singleBatch() {
+    let aSize = (rows: 2, columns: 3)
+    let bSize = (rows: 3, columns: 2)
+
+    let a: [Float] = [1, 2, 3, 4, 5, 6]
+    let b: [Float] = [7, 8, 9, 10, 11, 12]
+
+    let single = NumSwiftC.matmul1d(a, b: b, aSize: aSize, bSize: bSize)
+    let batchResult = NumSwiftC.matmul1dBatch(a, b: b, aSize: aSize, bSize: bSize, batchCount: 1)
+
+    XCTAssertEqual(batchResult, single)
+  }
+
+  // MARK: - NumSwiftC matmulBatch (2D Float)
+
+  func test_matmulBatch_matchesSingleCalls() {
+    let aSize = (rows: 3, columns: 3)
+    let bSize = (rows: 3, columns: 2)
+
+    let b: [[Float]] = [[2, 2],
+                         [2, 2],
+                         [2, 2]]
+
+    let a1: [[Float]] = [[1, 1, 1],
+                          [2, 2, 2],
+                          [3, 3, 3]]
+    let a2: [[Float]] = [[4, 4, 4],
+                          [5, 5, 5],
+                          [6, 6, 6]]
+
+    let single1 = NumSwiftC.matmul(a1, b: b, aSize: aSize, bSize: bSize)
+    let single2 = NumSwiftC.matmul(a2, b: b, aSize: aSize, bSize: bSize)
+
+    let batchResult = NumSwiftC.matmulBatch([a1, a2], b: b, aSize: aSize, bSize: bSize, batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], single1)
+    XCTAssertEqual(batchResult[1], single2)
+  }
+
+  // MARK: - NumSwiftFlat batch (Array<Float>)
+
+  func test_flat_conv2dBatch_matchesSingleCalls() {
+    let inputSize = (rows: 5, columns: 5)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [0, 1, 0,
+                           0, 1, 0,
+                           0, 1, 0]
+
+    let signal1: [Float] = [Float](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+
+    let single1 = NumSwiftFlat.conv2d(signal: signal1, filter: filter, strides: (1,1),
+                                       padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftFlat.conv2d(signal: signal2, filter: filter, strides: (1,1),
+                                       padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftFlat.conv2dBatch(signal: signal1 + signal2, filter: filter,
+                                                strides: (1,1), padding: .same,
+                                                filterSize: filterSize, inputSize: inputSize,
+                                                batchCount: 2)
+
+    let outputSize = single1.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single1)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single2)
+  }
+
+  func test_flat_transConv2dBatch_matchesSingleCalls() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [1, 0, 0,
+                           0, 1, 0,
+                           0, 0, 1]
+
+    let signal: [Float] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+
+    let single = NumSwiftFlat.transConv2d(signal: signal, filter: filter, strides: (1,1),
+                                           padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftFlat.transConv2dBatch(signal: signal + signal, filter: filter,
+                                                     strides: (1,1), padding: .valid,
+                                                     filterSize: filterSize, inputSize: inputSize,
+                                                     batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_flat_matmulBatch_matchesSingleCalls() {
+    let a1: [Float] = [1, 2, 3, 4, 5, 6]
+    let a2: [Float] = [7, 8, 9, 10, 11, 12]
+    let b: [Float] = [1, 0, 0, 1, 1, 1]
+
+    let single1 = NumSwiftFlat.matmul(a1, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+    let single2 = NumSwiftFlat.matmul(a2, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+
+    let batchResult = NumSwiftFlat.matmulBatch(a1 + a2, b, aRows: 2, aCols: 3,
+                                                bRows: 3, bCols: 2, batchCount: 2)
+
+    let outputSize = single1.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single1)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single2)
+  }
+
+  // MARK: - NumSwiftFlat batch (ContiguousArray<Float>)
+
+  func test_contiguous_conv2dBatch() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: ContiguousArray<Float> = [1, 0, 0, 1]
+    let signal: ContiguousArray<Float> = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    let single = NumSwiftFlat.conv2d(signal: signal, filter: filter, strides: (1,1),
+                                      padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchSignal = signal + signal
+    let batchResult = NumSwiftFlat.conv2dBatch(signal: batchSignal, filter: filter,
+                                                strides: (1,1), padding: .valid,
+                                                filterSize: filterSize, inputSize: inputSize,
+                                                batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(ContiguousArray(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(ContiguousArray(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_contiguous_transConv2dBatch() {
+    let inputSize = (rows: 2, columns: 2)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: ContiguousArray<Float> = [1, 1, 1, 1]
+    let signal: ContiguousArray<Float> = [1, 2, 3, 4]
+
+    let single = NumSwiftFlat.transConv2d(signal: signal, filter: filter, strides: (1,1),
+                                           padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftFlat.transConv2dBatch(signal: signal + signal, filter: filter,
+                                                     strides: (1,1), padding: .valid,
+                                                     filterSize: filterSize, inputSize: inputSize,
+                                                     batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(ContiguousArray(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(ContiguousArray(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_contiguous_matmulBatch() {
+    let a: ContiguousArray<Float> = [1, 2, 3, 4, 5, 6]
+    let b: ContiguousArray<Float> = [7, 8, 9, 10, 11, 12]
+
+    let single = NumSwiftFlat.matmul(a, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+
+    let batchResult = NumSwiftFlat.matmulBatch(a + a, b, aRows: 2, aCols: 3,
+                                                bRows: 3, bCols: 2, batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(ContiguousArray(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(ContiguousArray(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  // MARK: - NumSwiftFlatPointer batch (Float pointers)
+
+  func test_pointer_conv2dBatch() {
+    let inputSize = (rows: 5, columns: 5)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [0, 1, 0,
+                           0, 1, 0,
+                           0, 1, 0]
+
+    let signal1: [Float] = [Float](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+
+    let single1 = NumSwiftC.conv1d(signal: signal1, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.conv1d(signal: signal2, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    let batchedSignal = signal1 + signal2
+    let outputSize = single1.count
+    var result = [Float](repeating: 0, count: outputSize * 2)
+
+    batchedSignal.withUnsafeBufferPointer { sPtr in
+      filter.withUnsafeBufferPointer { fPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.conv2dBatch(signal: sPtr.baseAddress!, filter: fPtr.baseAddress!,
+                                   result: rPtr.baseAddress!, strides: (1,1), padding: .same,
+                                   filterSize: filterSize, inputSize: inputSize, batchCount: 2)
+        }
+      }
+    }
+
+    XCTAssertEqual(Array(result[0..<outputSize]), single1)
+    XCTAssertEqual(Array(result[outputSize..<outputSize * 2]), single2)
+  }
+
+  func test_pointer_transConv2dBatch() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [1, 0, 0,
+                           0, 1, 0,
+                           0, 0, 1]
+
+    let signal: [Float] = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+
+    let single = NumSwiftC.transConv1d(signal: signal, filter: filter, strides: (1,1),
+                                        padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchedSignal = signal + signal
+    let outputSize = single.count
+    var result = [Float](repeating: 0, count: outputSize * 2)
+
+    batchedSignal.withUnsafeBufferPointer { sPtr in
+      filter.withUnsafeBufferPointer { fPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.transConv2dBatch(signal: sPtr.baseAddress!, filter: fPtr.baseAddress!,
+                                        result: rPtr.baseAddress!, strides: (1,1), padding: .valid,
+                                        filterSize: filterSize, inputSize: inputSize, batchCount: 2)
+        }
+      }
+    }
+
+    XCTAssertEqual(Array(result[0..<outputSize]), single)
+    XCTAssertEqual(Array(result[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_pointer_matmulBatch() {
+    let a1: [Float] = [1, 2, 3, 4, 5, 6]
+    let a2: [Float] = [7, 8, 9, 10, 11, 12]
+    let b: [Float] = [1, 0, 0, 1, 1, 1]
+
+    let single1 = NumSwiftC.matmul1d(a1, b: b, aSize: (2, 3), bSize: (3, 2))
+    let single2 = NumSwiftC.matmul1d(a2, b: b, aSize: (2, 3), bSize: (3, 2))
+
+    let batchedA = a1 + a2
+    let outputSize = single1.count
+    var result = [Float](repeating: 0, count: outputSize * 2)
+
+    batchedA.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.matmulBatch(aPtr.baseAddress!, bPtr.baseAddress!,
+                                   result: rPtr.baseAddress!,
+                                   aRows: 2, aCols: 3, bRows: 3, bCols: 2, batchCount: 2)
+        }
+      }
+    }
+
+    XCTAssertEqual(Array(result[0..<outputSize]), single1)
+    XCTAssertEqual(Array(result[outputSize..<outputSize * 2]), single2)
+  }
+
+  // MARK: - Edge cases
+
+  func test_conv1dBatch_singleBatch() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [Float] = [1, 1, 1, 1]
+    let signal: [Float] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
+                                   padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.conv1dBatch(signal: signal, filter: filter,
+                                             strides: (1,1), padding: .valid,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 1)
+
+    XCTAssertEqual(batchResult, single)
+  }
+
+  func test_conv2dBatch_singleBatch() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [[Float]] = [[1, 1],
+                              [1, 1]]
+    let signal: [[Float]] = [[1, 2, 3],
+                              [4, 5, 6],
+                              [7, 8, 9]]
+
+    let single = NumSwiftC.conv2d(signal: signal, filter: filter, strides: (1,1),
+                                   padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.conv2dBatch(signals: [signal], filter: filter,
+                                             strides: (1,1), padding: .valid,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 1)
+
+    XCTAssertEqual(batchResult.count, 1)
+    XCTAssertEqual(batchResult[0], single)
+  }
+
+  func test_batch_withStrides() {
+    let inputSize = (rows: 4, columns: 4)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [Float] = [1, 0, 0, 1]
+    let signal: [Float] = [1, 2, 3, 4,
+                           5, 6, 7, 8,
+                           9, 10, 11, 12,
+                           13, 14, 15, 16]
+
+    let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (2,2),
+                                   padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.conv1dBatch(signal: signal + signal, filter: filter,
+                                             strides: (2,2), padding: .valid,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_matmulBatch_differentInputs() {
+    let aSize = (rows: 2, columns: 2)
+    let bSize = (rows: 2, columns: 2)
+
+    let b: [[Float]] = [[1, 0],
+                         [0, 1]]
+
+    let a1: [[Float]] = [[1, 2],
+                          [3, 4]]
+    let a2: [[Float]] = [[5, 6],
+                          [7, 8]]
+
+    let batchResult = NumSwiftC.matmulBatch([a1, a2], b: b, aSize: aSize, bSize: bSize, batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], a1)
+    XCTAssertEqual(batchResult[1], a2)
+  }
+
+  func test_transConv2dBatch_withStrides() {
+    let inputSize = (rows: 2, columns: 2)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [[Float]] = [[1, 1, 1],
+                              [1, 1, 1],
+                              [1, 1, 1]]
+
+    let signal1: [[Float]] = [[1, 2],
+                               [3, 4]]
+    let signal2: [[Float]] = [[5, 6],
+                               [7, 8]]
+
+    let single1 = NumSwiftC.transConv2d(signal: signal1, filter: filter, strides: (2,2),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.transConv2d(signal: signal2, filter: filter, strides: (2,2),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.transConv2dBatch(signals: [signal1, signal2], filter: filter,
+                                                  strides: (2,2), padding: .valid,
+                                                  filterSize: filterSize, inputSize: inputSize,
+                                                  batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], single1)
+    XCTAssertEqual(batchResult[1], single2)
+  }
+
+  func test_largeBatch_conv1d() {
+    let inputSize = (rows: 4, columns: 4)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float] = [Float](repeating: 1.0, count: 9)
+    let signal: [Float] = [Float](repeating: 1.0, count: 16)
+
+    let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
+                                   padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    var batchedSignal: [Float] = []
+    let batchCount = 8
+    for _ in 0..<batchCount {
+      batchedSignal.append(contentsOf: signal)
+    }
+
+    let batchResult = NumSwiftC.conv1dBatch(signal: batchedSignal, filter: filter,
+                                             strides: (1,1), padding: .same,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: batchCount)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * batchCount)
+    for b in 0..<batchCount {
+      XCTAssertEqual(Array(batchResult[b * outputSize..<(b + 1) * outputSize]), single,
+                     "Batch item \(b) mismatch")
+    }
+  }
+
+  // MARK: - Float16 Batch Tests
+
+  #if arch(arm64)
+
+  func test_conv1dBatch_float16_matchesSingleCalls() {
+    let inputSize = (rows: 5, columns: 5)
+    let filterSize = (rows: 3, columns: 3)
+
+    let filter: [Float16] = [0, 1, 0,
+                              0, 1, 0,
+                              0, 1, 0]
+
+    let signal1: [Float16] = [Float16](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float16] = [Float16](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+
+    let single1 = NumSwiftC.conv1d(signal: signal1, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.conv1d(signal: signal2, filter: filter, strides: (1,1),
+                                    padding: .same, filterSize: filterSize, inputSize: inputSize)
+
+    let batchedSignal = signal1 + signal2
+    let batchResult = NumSwiftC.conv1dBatch(signal: batchedSignal, filter: filter,
+                                             strides: (1,1), padding: .same,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 2)
+
+    let outputSize = single1.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single1)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single2)
+  }
+
+  func test_conv2dBatch_float16_matchesSingleCalls() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [[Float16]] = [[1, 0],
+                                [0, 1]]
+    let signal1: [[Float16]] = [[1, 2, 3],
+                                 [4, 5, 6],
+                                 [7, 8, 9]]
+    let signal2: [[Float16]] = [[9, 8, 7],
+                                 [6, 5, 4],
+                                 [3, 2, 1]]
+
+    let single1 = NumSwiftC.conv2d(signal: signal1, filter: filter, strides: (1,1),
+                                    padding: .valid, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.conv2d(signal: signal2, filter: filter, strides: (1,1),
+                                    padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.conv2dBatch(signals: [signal1, signal2], filter: filter,
+                                             strides: (1,1), padding: .valid,
+                                             filterSize: filterSize, inputSize: inputSize,
+                                             batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], single1)
+    XCTAssertEqual(batchResult[1], single2)
+  }
+
+  func test_transConv1dBatch_float16() {
+    let inputSize = (rows: 2, columns: 2)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [Float16] = [1, 1, 1, 1]
+    let signal: [Float16] = [1, 2, 3, 4]
+
+    let single = NumSwiftC.transConv1d(signal: signal, filter: filter, strides: (1,1),
+                                        padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.transConv1dBatch(signal: signal + signal, filter: filter,
+                                                  strides: (1,1), padding: .valid,
+                                                  filterSize: filterSize, inputSize: inputSize,
+                                                  batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_transConv2dBatch_float16() {
+    let inputSize = (rows: 2, columns: 2)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [[Float16]] = [[1, 1],
+                                [1, 1]]
+
+    let signal1: [[Float16]] = [[1, 2],
+                                 [3, 4]]
+    let signal2: [[Float16]] = [[5, 6],
+                                 [7, 8]]
+
+    let single1 = NumSwiftC.transConv2d(signal: signal1, filter: filter, strides: (1,1),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+    let single2 = NumSwiftC.transConv2d(signal: signal2, filter: filter, strides: (1,1),
+                                         padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftC.transConv2dBatch(signals: [signal1, signal2], filter: filter,
+                                                  strides: (1,1), padding: .valid,
+                                                  filterSize: filterSize, inputSize: inputSize,
+                                                  batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], single1)
+    XCTAssertEqual(batchResult[1], single2)
+  }
+
+  func test_matmul1dBatch_float16() {
+    let aSize = (rows: 2, columns: 3)
+    let bSize = (rows: 3, columns: 2)
+
+    let b: [Float16] = [1, 0, 0, 1, 1, 1]
+    let a1: [Float16] = [1, 2, 3, 4, 5, 6]
+    let a2: [Float16] = [7, 8, 9, 10, 11, 12]
+
+    let single1 = NumSwiftC.matmul1d(a1, b: b, aSize: aSize, bSize: bSize)
+    let single2 = NumSwiftC.matmul1d(a2, b: b, aSize: aSize, bSize: bSize)
+
+    let batchResult = NumSwiftC.matmul1dBatch(a1 + a2, b: b, aSize: aSize, bSize: bSize, batchCount: 2)
+
+    let outputSize = single1.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single1)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single2)
+  }
+
+  func test_matmulBatch_float16() {
+    let aSize = (rows: 2, columns: 2)
+    let bSize = (rows: 2, columns: 2)
+
+    let b: [[Float16]] = [[1, 0],
+                           [0, 1]]
+    let a1: [[Float16]] = [[1, 2],
+                            [3, 4]]
+    let a2: [[Float16]] = [[5, 6],
+                            [7, 8]]
+
+    let batchResult = NumSwiftC.matmulBatch([a1, a2], b: b, aSize: aSize, bSize: bSize, batchCount: 2)
+
+    XCTAssertEqual(batchResult.count, 2)
+    XCTAssertEqual(batchResult[0], a1)
+    XCTAssertEqual(batchResult[1], a2)
+  }
+
+  func test_flat_conv2dBatch_float16() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [Float16] = [1, 1, 1, 1]
+    let signal: [Float16] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    let single = NumSwiftFlat.conv2d(signal: signal, filter: filter, strides: (1,1),
+                                      padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchResult = NumSwiftFlat.conv2dBatch(signal: signal + signal, filter: filter,
+                                                strides: (1,1), padding: .valid,
+                                                filterSize: filterSize, inputSize: inputSize,
+                                                batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_flat_matmulBatch_float16() {
+    let a: [Float16] = [1, 2, 3, 4, 5, 6]
+    let b: [Float16] = [7, 8, 9, 10, 11, 12]
+
+    let single = NumSwiftFlat.matmul(a, b, aRows: 2, aCols: 3, bRows: 3, bCols: 2)
+
+    let batchResult = NumSwiftFlat.matmulBatch(a + a, b, aRows: 2, aCols: 3,
+                                                bRows: 3, bCols: 2, batchCount: 2)
+
+    let outputSize = single.count
+    XCTAssertEqual(batchResult.count, outputSize * 2)
+    XCTAssertEqual(Array(batchResult[0..<outputSize]), single)
+    XCTAssertEqual(Array(batchResult[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_pointer_conv2dBatch_float16() {
+    let inputSize = (rows: 3, columns: 3)
+    let filterSize = (rows: 2, columns: 2)
+
+    let filter: [Float16] = [1, 0, 0, 1]
+    let signal: [Float16] = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
+                                   padding: .valid, filterSize: filterSize, inputSize: inputSize)
+
+    let batchedSignal = signal + signal
+    let outputSize = single.count
+    var result = [Float16](repeating: 0, count: outputSize * 2)
+
+    batchedSignal.withUnsafeBufferPointer { sPtr in
+      filter.withUnsafeBufferPointer { fPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.conv2dBatch(signal: sPtr.baseAddress!, filter: fPtr.baseAddress!,
+                                   result: rPtr.baseAddress!, strides: (1,1), padding: .valid,
+                                   filterSize: filterSize, inputSize: inputSize, batchCount: 2)
+        }
+      }
+    }
+
+    XCTAssertEqual(Array(result[0..<outputSize]), single)
+    XCTAssertEqual(Array(result[outputSize..<outputSize * 2]), single)
+  }
+
+  func test_pointer_matmulBatch_float16() {
+    let a: [Float16] = [1, 2, 3, 4, 5, 6]
+    let b: [Float16] = [7, 8, 9, 10, 11, 12]
+
+    let single = NumSwiftC.matmul1d(a, b: b, aSize: (2, 3), bSize: (3, 2))
+
+    let batchedA = a + a
+    let outputSize = single.count
+    var result = [Float16](repeating: 0, count: outputSize * 2)
+
+    batchedA.withUnsafeBufferPointer { aPtr in
+      b.withUnsafeBufferPointer { bPtr in
+        result.withUnsafeMutableBufferPointer { rPtr in
+          NumSwiftFlat.matmulBatch(aPtr.baseAddress!, bPtr.baseAddress!,
+                                   result: rPtr.baseAddress!,
+                                   aRows: 2, aCols: 3, bRows: 3, bCols: 2, batchCount: 2)
+        }
+      }
+    }
+
+    XCTAssertEqual(Array(result[0..<outputSize]), single)
+    XCTAssertEqual(Array(result[outputSize..<outputSize * 2]), single)
+  }
+
+  #endif
+}

--- a/Tests/NumSwiftTests/BatchTests.swift
+++ b/Tests/NumSwiftTests/BatchTests.swift
@@ -13,8 +13,8 @@ final class BatchTests: XCTestCase {
                            0, 1, 0,
                            0, 1, 0]
 
-    let signal1: [Float] = [Float](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
-    let signal2: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+    let signal1: [Float] = [[Float]](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float] = [[Float]](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
 
     let single1 = NumSwiftC.conv1d(signal: signal1, filter: filter, strides: (1,1),
                                     padding: .same, filterSize: filterSize, inputSize: inputSize)
@@ -41,7 +41,7 @@ final class BatchTests: XCTestCase {
                            0, 1, 0,
                            0, 0, 1]
 
-    let signal: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+    let signal: [Float] = [[Float]](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
     let batchedSignal = signal + signal + signal
 
     let single = NumSwiftC.conv1d(signal: signal, filter: filter, strides: (1,1),
@@ -249,8 +249,8 @@ final class BatchTests: XCTestCase {
                            0, 1, 0,
                            0, 1, 0]
 
-    let signal1: [Float] = [Float](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
-    let signal2: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+    let signal1: [Float] = [[Float]](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float] = [[Float]](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
 
     let single1 = NumSwiftFlat.conv2d(signal: signal1, filter: filter, strides: (1,1),
                                        padding: .same, filterSize: filterSize, inputSize: inputSize)
@@ -379,8 +379,8 @@ final class BatchTests: XCTestCase {
                            0, 1, 0,
                            0, 1, 0]
 
-    let signal1: [Float] = [Float](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
-    let signal2: [Float] = [Float](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+    let signal1: [Float] = [[Float]](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float] = [[Float]](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
 
     let single1 = NumSwiftC.conv1d(signal: signal1, filter: filter, strides: (1,1),
                                     padding: .same, filterSize: filterSize, inputSize: inputSize)
@@ -616,8 +616,8 @@ final class BatchTests: XCTestCase {
                               0, 1, 0,
                               0, 1, 0]
 
-    let signal1: [Float16] = [Float16](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
-    let signal2: [Float16] = [Float16](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
+    let signal1: [Float16] = [[Float16]](repeating: [0,0,1,0,0], count: 5).flatMap { $0 }
+    let signal2: [Float16] = [[Float16]](repeating: [1,0,0,0,1], count: 5).flatMap { $0 }
 
     let single1 = NumSwiftC.conv1d(signal: signal1, filter: filter, strides: (1,1),
                                     padding: .same, filterSize: filterSize, inputSize: inputSize)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add batch processing capabilities to core arithmetic functions like `conv2d` and `matmul` to enable efficient batch data processing.

This PR introduces new `_batch` C functions and their Swift wrappers for operations such as `conv1d`, `conv2d`, `transConv1d`, `transConv2d`, `matmul1d`, and `matmul`. These functions now iterate over batch items, applying the existing optimized single-item C functions. Element-wise operations were found to inherently support batching by adjusting input sizes and thus did not require modification.

<div><a href="https://cursor.com/agents/bc-85ea2043-7c4b-4921-b1a0-41d776b42997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85ea2043-7c4b-4921-b1a0-41d776b42997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->